### PR TITLE
Добавлена возможность отрезать лишную часть пути у issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | -c; --commit      | Коммит в репозитории, по которому запускалось сканирование                                                                             | Нет, по умолчанию master                              |
 | -bt; --build-tool | Сборщик (--help для просмотра всех сборщиков)                                                                                          | Нет, по умолчанию maven                               |
 | --stage           | Стадия экземпляра (ST - System Test, UAT - User Acceptance Test, IAT - Integration Acceptance Test, STG - Stage, PROD - Production)    | Нет                                                   |
+| -pr; --path_replace           | Строковое значение для удаления части пути из fileName в конечном json    | Нет                                                   |
 
 ### Список поддерживаемых форматов
 bandit, burp, checkov, gitleaks, gosec, horusec, mobsf, sarif, semgrep, spotbugs, trufflehog, cyclonedx

--- a/hub/parsers/hub_parser.py
+++ b/hub/parsers/hub_parser.py
@@ -115,11 +115,14 @@ class HubParser:
         if finding.file_key not in self.locations:
             scanner_type = self.__get_scanner_type(finding)
             if scanner_type == ScannerTypes.SAST.value:
+                file_name = finding.file_path or 'Unknown'
+                if self.args.path_replace:
+                    file_name = file_name.replace(self.args.path_replace, '')
                 self.locations[finding.file_key] = LocationSast(
                     type=self.args.type,
                     id=finding.file_key if finding.file_key else 'Unknown',
                     sourceId=self.source.id,
-                    fileName=finding.file_path if finding.file_path else 'Unknown'
+                    fileName=file_name
                 )
             elif scanner_type == ScannerTypes.DAST.value:
                 self.locations[finding.file_key] = LocationDast(

--- a/main.py
+++ b/main.py
@@ -95,6 +95,12 @@ if __name__ == '__main__':
         help="Stage of instance",
         required=False
     )
+    parser.add_argument(
+        "-pr", "--path-replace",
+        type=str,
+        help="Specify the path to be cut from the results json (default: None)",
+        default=None
+    )
 
     args = parser.parse_args()
 

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -21,6 +21,7 @@ class ArgsBase:
     name: str = 'hub-tool-converters'
     url: str = 'https://github.com/Swordfish-Security/hub-tool-converters.git'
     format: str | None = None
+    path_replace: str | None = None
 
 
 class ArgsCodebase(ArgsBase):


### PR DESCRIPTION
Новый параметр -pr; --path_replace   

Пример эксплуатации:

... --path_replace=${CI_PROJECT_DIR}/

`Путь с рудиментами: 

"fileName": "/builds/devsecops3000Pro/private/test-projects-and-other-trash/appsec.hub/genearal-test-pipe/code_scan/test_code_scan/PHP/.env.example",
 

Путь после применения параметра

code_scan/test_code_scan/PHP/.env.example`