### PR TITLE
fix: commit validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 | -o; --output      | Путь где будет создан отчет в формате AppSec.HUB                                                                                       | Да                                                    |
 | -n; --name        | Название репозитория в AppSec.Hub/артефакта/инстанса                                                                                   | Да                                                    |
 | -u; --url         | Урл репозитория/артефакта/инстанса                                                                                                     | Да                                                    |
+| -c; --commit      | Коммит в репозитории, по которому запускалось сканирование                                                                             | Да                                                    |
 | --format          | Формат входного файла (bandit, burp, checkov, gitleaks, gosec, horusec, mobsf, sarif, semgrep, spotbugs, trufflehog, svace, cyclonedx) | Нет, по умолчанию взято значение из аргумента scanner |
 | -b; --branch      | Ветка в репозитории, по которой запускалось сканирование                                                                               | Нет, по умолчанию master                              |
-| -c; --commit      | Коммит в репозитории, по которому запускалось сканирование                                                                             | Нет, по умолчанию master                              |
 | -bt; --build-tool | Сборщик (--help для просмотра всех сборщиков)                                                                                          | Нет, по умолчанию maven                               |
 | --stage           | Стадия экземпляра (ST - System Test, UAT - User Acceptance Test, IAT - Integration Acceptance Test, STG - Stage, PROD - Production)    | Нет                                                   |
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 | -o; --output      | Путь где будет создан отчет в формате AppSec.HUB                                                                                       | Да                                                    |
 | -n; --name        | Название репозитория в AppSec.Hub/артефакта/инстанса                                                                                   | Да                                                    |
 | -u; --url         | Урл репозитория/артефакта/инстанса                                                                                                     | Да                                                    |
-| -c; --commit      | Коммит в репозитории, по которому запускалось сканирование                                                                             | Да                                                    |
 | --format          | Формат входного файла (bandit, burp, checkov, gitleaks, gosec, horusec, mobsf, sarif, semgrep, spotbugs, trufflehog, svace, cyclonedx) | Нет, по умолчанию взято значение из аргумента scanner |
 | -b; --branch      | Ветка в репозитории, по которой запускалось сканирование                                                                               | Нет, по умолчанию master                              |
+| -c; --commit      | Коммит в репозитории, по которому запускалось сканирование                                                                             | Нет                                                   |
 | -bt; --build-tool | Сборщик (--help для просмотра всех сборщиков)                                                                                          | Нет, по умолчанию maven                               |
 | --stage           | Стадия экземпляра (ST - System Test, UAT - User Acceptance Test, IAT - Integration Acceptance Test, STG - Stage, PROD - Production)    | Нет                                                   |
 

--- a/main.py
+++ b/main.py
@@ -78,8 +78,8 @@ if __name__ == '__main__':
     parser.add_argument(
         "-c", "--commit",
         type=str,
-        help="AppSec.Hub repository's commit (default: master)",
-        default="master"
+        help="AppSec.Hub repository's commit",
+        required=False
     )
     parser.add_argument(
         "-bt", "--build-tool",


### PR DESCRIPTION
С версией 2025.1.1 появилась валиадция параметра commit при старте сканов. Эта же валидация, как оказалось, относится и к импорту отчётов, полученных через конвертер. Если в конвертере не указать флаг commit, при импорте отчёта хаб пожалуется на то, что параметр коммита не прошёл валидацию

![image](https://github.com/user-attachments/assets/e7782208-4f1d-4cc4-84d2-5060c1df6a2f)

![image](https://github.com/user-attachments/assets/a2297589-ea43-46cd-8c20-131333fae54c)
