### PR TITLE
fix: critical severity for semgrep

### DIFF
--- a/converters/parsers/semgrep.py
+++ b/converters/parsers/semgrep.py
@@ -84,10 +84,12 @@ class SemgrepParser(object):
         return list(dupes.values())
 
     def convert_severity(self, val):
-        if "WARNING" == val.upper():
-            return "Medium"
+        if "CRITICAL" == val.upper():
+            return "Critical"
         elif "ERROR" == val.upper():
             return "High"
+        elif "WARNING" == val.upper():
+            return "Medium"
         elif "INFO" == val.upper():
             return "Info"
         else:


### PR DESCRIPTION
В отчёте Semgrep (по крайней мере в версии 1.114.0) может присутствовать Severity, равный Critical. Конвертер об это спотыкается и не может сконвертировать отчёт
![image](https://github.com/user-attachments/assets/9161ccaa-2bba-4c2f-b08a-b8f239beebbd)
