### PR TITLE
Removing Open status from json scheme

### DIFF
--- a/tests/hub_schema.json
+++ b/tests/hub_schema.json
@@ -1047,7 +1047,7 @@
     "status": {
       "type": "string",
       "enum": [
-        "To Verify", "Confirmed", "Open", "Fixed", "False Positive", "Accepted risk"
+        "To Verify", "Confirmed", "Fixed", "False Positive", "Accepted risk"
       ]
     },
 


### PR DESCRIPTION
Статус Open больше не поддерживается AppSec.Hub