### PR TITLE
feat: add SolidPoint DAST parser with v1.0.2 schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@
 | -o; --output      | Путь где будет создан отчет в формате AppSec.HUB                                                                                       | Да                                                    |
 | -n; --name        | Название репозитория в AppSec.Hub/артефакта/инстанса                                                                                   | Да                                                    |
 | -u; --url         | Урл репозитория/артефакта/инстанса                                                                                                     | Да                                                    |
-| --format          | Формат входного файла (bandit, burp, checkov, gitleaks, gosec, horusec, mobsf, sarif, semgrep, spotbugs, trufflehog, svace, cyclonedx) | Нет, по умолчанию взято значение из аргумента scanner |
+| --format          | Формат входного файла (bandit, burp, checkov, gitleaks, gosec, horusec, mobsf, sarif, semgrep, solidpoint, spotbugs, trufflehog, svace, cyclonedx) | Нет, по умолчанию взято значение из аргумента scanner |
 | -b; --branch      | Ветка в репозитории, по которой запускалось сканирование                                                                               | Нет, по умолчанию master                              |
 | -c; --commit      | Коммит в репозитории, по которому запускалось сканирование                                                                             | Нет                                                   |
 | -bt; --build-tool | Сборщик (--help для просмотра всех сборщиков)                                                                                          | Нет, по умолчанию maven                               |
 | --stage           | Стадия экземпляра (ST - System Test, UAT - User Acceptance Test, IAT - Integration Acceptance Test, STG - Stage, PROD - Production)    | Нет                                                   |
+| --report-version  | Версия формата отчёта AppSec.HUB (1.0.1 или 1.0.2)                                                                                    | Нет, по умолчанию 1.0.1                               |
 
 ### Список поддерживаемых форматов
 
-bandit, burp, checkov, gitleaks, gosec, horusec, mobsf, sarif, semgrep, spotbugs, trufflehog, cyclonedx, kaspersky-cs, svace(только .csv, в формате .sarif запускать через sarif)
+bandit, burp, checkov, gitleaks, gosec, horusec, mobsf, sarif, semgrep, solidpoint, spotbugs, trufflehog, cyclonedx, kaspersky-cs, svace(только .csv, в формате .sarif запускать через sarif)
 
 ## Пример запуска
 
@@ -63,6 +64,11 @@ python main.py -s svace -t CODEBASE --format sarif -f tests/codebase/svace/svace
 
 ```bash
 python main.py -s kaspersky-cs -t ARTIFACT -f input-file.json -o output-file.json -n artifact_name -u https://artifact-url.rpm
+```
+
+5. Запуск конвертера для SolidPoint DAST
+```bash
+python main.py -s solidpoint -t INSTANCE -f solidpoint_report.json -o solidpoint_hub.json -n my-app -u https://my-app.example.com --stage ST
 ```
 
 ## Запуск тестов

--- a/converters/models/additional.py
+++ b/converters/models/additional.py
@@ -88,6 +88,8 @@ class AdditionalFields:
             self.file_key = 'Unknown'
 
     def __parse_dupe_key(self) -> None:
+        if self.dupe_key:
+            return
         try:
             key = self.title
             if self.secret:

--- a/converters/parsers/solidpoint.py
+++ b/converters/parsers/solidpoint.py
@@ -1,0 +1,249 @@
+import base64
+import hashlib
+import json
+import logging
+
+from converters.models import Endpoint, Finding
+
+logger = logging.getLogger(__name__)
+
+
+class SolidpointParser(object):
+    """
+    Parser for SolidPoint DAST scanner JSON reports.
+
+    SolidPoint reports contain two sections:
+      - endpoints: HTTP endpoints scanned with HAR data
+      - resources: web pages/resources analyzed
+
+    Each section contains tags with vulnerability findings.
+    Only tags with type="IssueFound" are processed.
+    """
+
+    def get_scan_types(self):
+        return ["SolidPoint Scan"]
+
+    def get_label_for_scan_types(self, scan_type):
+        return "SolidPoint Scan"
+
+    def get_description_for_scan_types(self, scan_type):
+        return (
+            "Import SolidPoint DAST findings in JSON format. "
+            "The parser processes both 'endpoints' and 'resources' sections "
+            "and extracts IssueFound tags with payloads, CWE, CVSS data."
+        )
+
+    def get_findings(self, filename, test):
+        data = json.load(filename)
+        items = {}
+
+        # Process endpoints
+        for endpoint in data.get("endpoints", []):
+            har = endpoint.get("har", {})
+            for tag in endpoint.get("tags", []):
+                finding = self._parse_tag(tag, har=har)
+                if finding:
+                    self._merge_finding(items, finding)
+
+        # Process resources
+        for resource in data.get("resources", []):
+            res_info = resource.get("resource", {})
+            for tag in resource.get("tags", []):
+                finding = self._parse_tag(tag, resource_info=res_info)
+                if finding:
+                    self._merge_finding(items, finding)
+
+        return list(items.values())
+
+    def _merge_finding(self, items, finding):
+        """Merge or add finding using unique_id_from_tool as dedup key."""
+        dupe_key = finding.unique_id_from_tool
+        if dupe_key in items:
+            existing = items[dupe_key]
+            # Merge endpoints
+            if finding.unsaved_endpoints:
+                existing.unsaved_endpoints = (
+                    (existing.unsaved_endpoints or []) + finding.unsaved_endpoints
+                )
+            # Merge request/response pairs
+            if finding.unsaved_req_resp:
+                existing.unsaved_req_resp = (
+                    (existing.unsaved_req_resp or []) + finding.unsaved_req_resp
+                )
+        else:
+            items[dupe_key] = finding
+
+    def _parse_tag(self, tag, har=None, resource_info=None):
+        """Parse a single tag and return a Finding if it's an IssueFound."""
+        attrs = tag.get("attributes", {})
+
+        if attrs.get("type") != "IssueFound":
+            return None
+
+        issue_name = attrs.get("issue", "Unknown Issue")
+        issue_id = attrs.get("issueId", "")
+        severity = self._normalize_severity(attrs.get("severity", "info"))
+        analyzer = attrs.get("analyzer", "")
+        module_name = attrs.get("moduleName", "")
+        confidence = attrs.get("confidence", "")
+        description_text = attrs.get("description", "")
+
+        # URL from tag attributes or HAR or resource
+        url = attrs.get("url", "")
+        if not url and har:
+            url = har.get("url", "")
+        if not url and resource_info:
+            url = resource_info.get("url", "")
+
+        # HTTP method from HAR
+        method = ""
+        if har:
+            method = har.get("method", "")
+
+        # CWE
+        cwe_list = attrs.get("cwe", [])
+        cwe = 0
+        if cwe_list:
+            # Extract numeric CWE ID from "CWE-XXX" format
+            cwe_str = cwe_list[0]
+            try:
+                cwe = int(cwe_str.replace("CWE-", ""))
+            except (ValueError, AttributeError):
+                cwe = 0
+
+        # CVSS
+        cvss_list = attrs.get("cvss", [])
+        cvss3_score = None
+        cvss3_vector = None
+        if cvss_list:
+            cvss_entry = cvss_list[0]
+            cvss3_score = str(cvss_entry.get("score", ""))
+            cvss3_vector = cvss_entry.get("metrics", "")
+
+        # Build description
+        description_parts = []
+        if method and url:
+            description_parts.append(f"**URL:** {method} {url}")
+        elif url:
+            description_parts.append(f"**URL:** {url}")
+
+        if analyzer:
+            description_parts.append(f"**Analyzer:** {analyzer}")
+        if module_name and module_name != analyzer:
+            description_parts.append(f"**Module:** {module_name}")
+        if confidence:
+            description_parts.append(f"**Confidence:** {confidence}")
+        if description_text:
+            description_parts.append(f"\n{description_text}")
+
+        # Process payloads
+        unsaved_req_resp = []
+        payload_descriptions = []
+        payloads = attrs.get("payloads", [])
+        for payload_entry in payloads:
+            # Payload details text
+            details = payload_entry.get("details", "")
+            if details:
+                payload_descriptions.append(details)
+
+            # Payload data
+            payload_data_list = payload_entry.get("payload", [])
+            for pd in payload_data_list:
+                data_value = pd.get("data", "")
+                if data_value:
+                    payload_descriptions.append(f"**Payload:** `{data_value}`")
+
+            # Request/Response blobs (base64 encoded)
+            request_blob = payload_entry.get("request", {})
+            response_blob = payload_entry.get("response", {})
+
+            req_text = self._decode_blob(request_blob)
+            resp_text = self._decode_blob(response_blob)
+
+            if req_text or resp_text:
+                unsaved_req_resp.append({
+                    "req": req_text or "",
+                    "resp": resp_text or ""
+                })
+
+        if payload_descriptions:
+            description_parts.append("\n**Payloads:**")
+            for pd in payload_descriptions:
+                description_parts.append(pd)
+
+        full_description = "\n".join(description_parts)
+
+        # Build the Finding object
+        # Build impact/mitigation from description or empty
+        impact = description_text if description_text else ""
+        mitigation = ""
+
+        finding = Finding(
+            title=issue_name,
+            url=url,
+            severity=severity,
+            description=full_description,
+            impact=impact,
+            mitigation=mitigation,
+            cwe=cwe,
+            cvss3_score=cvss3_score,
+            cvss3_vector=cvss3_vector,
+            false_p=False,
+            duplicate=False,
+            out_of_scope=False,
+            dynamic_finding=True,
+            static_finding=False,
+            unique_id_from_tool=issue_id,
+            vuln_id_from_tool=issue_name,
+        )
+
+        # Set dupe_key based on issueId to prevent false deduplication
+        # (e.g. multiple "HTTP Missing Security Headers" with same title/description but different issueId)
+        finding.dupe_key = hashlib.md5(issue_id.encode("utf-8")).hexdigest()
+
+        # Endpoint
+        if url:
+            try:
+                finding.unsaved_endpoints = [Endpoint.from_uri(url)]
+            except (ValueError, Exception) as e:
+                logger.warning(f"Failed to parse endpoint URL '{url}': {e}")
+                finding.unsaved_endpoints = []
+        else:
+            finding.unsaved_endpoints = []
+
+        # Request/Response pairs
+        finding.unsaved_req_resp = unsaved_req_resp
+
+        return finding
+
+    def _decode_blob(self, blob_obj):
+        """Decode a base64 blob object to text."""
+        if not blob_obj or not isinstance(blob_obj, dict):
+            return ""
+        blob_data = blob_obj.get("blob", "")
+        blob_type = blob_obj.get("type", "")
+        if not blob_data or blob_type != "blob":
+            return ""
+        try:
+            return base64.b64decode(blob_data).decode("utf-8", "replace")
+        except Exception:
+            try:
+                # If full decode fails, try to get at least the header
+                raw = base64.b64decode(blob_data)
+                parts = raw.split(b"\r\n\r\n", 1)
+                header = parts[0].decode("utf-8", "replace")
+                return header + "\r\n\r\n<Binary Redacted Data>"
+            except Exception:
+                return ""
+
+    def _normalize_severity(self, severity):
+        """Normalize SolidPoint severity to Hub-compatible format."""
+        severity_map = {
+            "critical": "Critical",
+            "high": "High",
+            "medium": "Medium",
+            "low": "Low",
+            "info": "Info",
+            "informational": "Info",
+        }
+        return severity_map.get(severity.lower(), "Info")

--- a/hub/models/hub.py
+++ b/hub/models/hub.py
@@ -36,7 +36,22 @@ class Report:
         result = asdict(self)
         result["$schema"] = self.schema
         del result["schema"]
+        # Clean up optional DAST fields (httpRequest/httpResponse) when not set
+        self._remove_optional_dast_fields(result)
         return result
+
+    @staticmethod
+    def _remove_optional_dast_fields(d):
+        """Remove httpRequest/httpResponse keys when they are None (v1.0.1 compat)."""
+        if isinstance(d, dict):
+            for key in ("httpRequest", "httpResponse"):
+                if key in d and d[key] is None:
+                    del d[key]
+            for v in d.values():
+                Report._remove_optional_dast_fields(v)
+        elif isinstance(d, list):
+            for item in d:
+                Report._remove_optional_dast_fields(item)
 
 
 @dataclass(kw_only=False, eq=False, order=False)
@@ -78,6 +93,13 @@ class FindingHubSast:
 
 
 @dataclass(kw_only=False, eq=False, order=False)
+class HttpMessage:
+    """Structured HTTP message for v1.0.2 schema."""
+    header: str = ""
+    body: str = ""
+
+
+@dataclass(kw_only=False, eq=False, order=False)
 class FindingHubDast:
     type: str
     id: str
@@ -86,6 +108,8 @@ class FindingHubDast:
     url: str
     status: str
     description: str
+    httpRequest: HttpMessage = None
+    httpResponse: HttpMessage = None
 
     def __init__(
             self,
@@ -95,7 +119,9 @@ class FindingHubDast:
             url: str,
             description: str,
             status: str,
-            type: str
+            type: str,
+            httpRequest: HttpMessage = None,
+            httpResponse: HttpMessage = None
     ):
         self.type = type
         self.id = idx
@@ -104,6 +130,8 @@ class FindingHubDast:
         self.url = url
         self.description = description
         self.status = status
+        self.httpRequest = httpRequest
+        self.httpResponse = httpResponse
         super().__init__()
 
 

--- a/hub/parsers/hub_parser.py
+++ b/hub/parsers/hub_parser.py
@@ -5,7 +5,7 @@ from typing import Any
 from config.enums import SourceTypes, ScannerTypes
 from config.constances import PARSERS_NAMES_TO_FIX
 from converters.models import Finding
-from hub.models.hub import ScanResult, Scan, ScanDetail, Report, FindingHubSast, FindingHubDast, FindingHubScaS
+from hub.models.hub import ScanResult, Scan, ScanDetail, Report, FindingHubSast, FindingHubDast, FindingHubScaS, HttpMessage
 from hub.models.location import LocationSast, LocationDast, LocationSca, LocationStack
 from hub.models.rule import Rule, RuleCwe, RuleSCA
 from hub.models.source import SourceSast, SourceDast, SourceArtifact
@@ -19,6 +19,7 @@ class HubParser:
         self.results = results
 
         self.args = args
+        self.report_version = getattr(args, 'report_version', '1.0.1')
         self.__create_source()
 
         self.rules: dict[str, Rule] = {}
@@ -61,16 +62,57 @@ class HubParser:
 
     def __parse_reqresps(self, finding: Finding):
         """
-        Save request and responses in descriptions
+        Save request and responses.
+        For v1.0.2: populate structured httpRequest/httpResponse on DAST findings.
+        For v1.0.1: append to description as before.
         """
-        if hasattr(finding, "unsaved_req_resp") and isinstance(finding.unsaved_req_resp, list):
+        if not hasattr(finding, "unsaved_req_resp") or not isinstance(finding.unsaved_req_resp, list):
+            return
+
+        hub_finding = self.findings.get(finding.dupe_key)
+        if not hub_finding:
+            return
+
+        if (self.report_version == "1.0.2"
+                and isinstance(hub_finding, FindingHubDast)
+                and finding.unsaved_req_resp):
+            # For v1.0.2, use structured httpRequest/httpResponse from first req/resp pair
+            first_rr = finding.unsaved_req_resp[0] if finding.unsaved_req_resp else None
+            if first_rr and isinstance(first_rr, dict):
+                req_raw = first_rr.get("req", "")
+                resp_raw = first_rr.get("resp", "")
+                hub_finding.httpRequest = self.__split_http_message(req_raw)
+                hub_finding.httpResponse = self.__split_http_message(resp_raw)
+
+            # Append remaining req/resp pairs to description
+            for req_resp in finding.unsaved_req_resp[1:]:
+                text = ''
+                if isinstance(req_resp, dict):
+                    for key, value in req_resp.items():
+                        text += f'\n{key}: {value}\n'
+                        text = markdown.markdown(text, extensions=['nl2br']).replace('\n', '')
+                hub_finding.description += text
+        else:
+            # v1.0.1 behavior: append everything to description
             for req_resp in finding.unsaved_req_resp:
                 text = ''
                 if isinstance(req_resp, dict):
                     for key, value in req_resp.items():
                         text += f'\n{key}: {value}\n'
                         text = markdown.markdown(text, extensions=['nl2br']).replace('\n', '')
-                self.findings[finding.dupe_key].description += text
+                hub_finding.description += text
+
+    @staticmethod
+    def __split_http_message(raw: str) -> HttpMessage:
+        """Split raw HTTP message into header and body parts."""
+        if not raw:
+            return HttpMessage(header="", body="")
+        # HTTP messages separate headers from body with double CRLF
+        for separator in ["\r\n\r\n", "\n\n"]:
+            if separator in raw:
+                parts = raw.split(separator, 1)
+                return HttpMessage(header=parts[0], body=parts[1] if len(parts) > 1 else "")
+        return HttpMessage(header=raw, body="")
 
     def __parse_finding(self, finding: Finding):
         scanner_type = self.__get_scanner_type(finding)
@@ -215,6 +257,7 @@ class HubParser:
             tool={'product': f"{self.args.scanner}"}
         )
         report = Report(
+            version=self.report_version,
             scans=[scan]
         )
         report = report.to_dict()

--- a/main.py
+++ b/main.py
@@ -94,6 +94,14 @@ if __name__ == '__main__':
         help="Stage of instance",
         required=False
     )
+    parser.add_argument(
+        "--report-version",
+        type=str,
+        choices=["1.0.1", "1.0.2"],
+        help="AppSec.Hub report schema version (default: 1.0.1)",
+        default="1.0.1",
+        dest="report_version"
+    )
 
     args = parser.parse_args()
 

--- a/tests/hub_schema.json
+++ b/tests/hub_schema.json
@@ -12,7 +12,10 @@
     },
     "version": {
       "description": "The Hub.Report format version of this log file",
-      "enum": [ "1.0.1" ],
+      "enum": [
+        "1.0.1",
+        "1.0.2"
+      ],
       "type": "string"
     },
     "scans": {
@@ -24,16 +27,17 @@
     }
   },
   "required": [
-    "version", "scans"
+    "version",
+    "scans"
   ],
-
-
   "definitions": {
     "scan": {
       "description": "Describes a single run of an analysis tool, and contains the reported output of that run",
       "type": "object",
       "required": [
-        "source", "tool", "results"
+        "source",
+        "tool",
+        "results"
       ],
       "properties": {
         "scanDetails": {
@@ -70,7 +74,6 @@
         }
       }
     },
-
     "scanDetails": {
       "type": "object",
       "properties": {
@@ -89,7 +92,7 @@
         "baselineGuid": {
           "description": "The 'guid' property of a previous 'scan'",
           "type": "string"
-            },
+        },
         "scanDate": {
           "description": "The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification",
           "type": "string",
@@ -105,18 +108,23 @@
         }
       }
     },
-
     "codebase": {
       "description": "Codebase information that was analyzed",
       "type": "object",
       "required": [
-        "type", "id", "url", "checkoutPath", "vcsType"
+        "type",
+        "id",
+        "url",
+        "checkoutPath",
+        "vcsType"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Source type",
-          "enum": [ "codebase" ]
+          "enum": [
+            "codebase"
+          ]
         },
         "id": {
           "type": "string",
@@ -155,14 +163,18 @@
           "pattern": "git",
           "type": "string",
           "description": "Type of VCS repository - \"git\"",
-          "enum": [ "git" ]
+          "enum": [
+            "git"
+          ]
         },
         "buildTool": {
           "pattern": "maven|gradle|nuget|npm|pip",
           "type": "string",
           "description": "Build tool used to compile this source code. Default: maven",
           "example": "maven",
-          "enum": [ "maven" ]
+          "enum": [
+            "maven"
+          ]
         },
         "branchFilter": {
           "maxLength": 128,
@@ -173,19 +185,22 @@
         }
       }
     },
-
     "artifact": {
       "description": "Artifact information that was analyzed",
       "type": "object",
-
       "required": [
-        "type", "id", "name", "url"
+        "type",
+        "id",
+        "name",
+        "url"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Source type",
-          "enum": [ "artifact" ]
+          "enum": [
+            "artifact"
+          ]
         },
         "id": {
           "type": "string",
@@ -203,18 +218,21 @@
         }
       }
     },
-
     "instance": {
       "description": "Instance information that was analyzed",
       "type": "object",
       "required": [
-        "type", "id", "url"
+        "type",
+        "id",
+        "url"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Source type",
-          "enum": [ "instance" ]
+          "enum": [
+            "instance"
+          ]
         },
         "id": {
           "type": "string",
@@ -233,16 +251,22 @@
         "stage": {
           "type": "string",
           "description": "Stage (system test, integration acceptance test, user acceptance test, stage, production)",
-          "enum": ["ST", "IAT", "UAT", "STG", "PROD"]
+          "enum": [
+            "ST",
+            "IAT",
+            "UAT",
+            "STG",
+            "PROD"
+          ]
         }
       }
     },
-
     "tool": {
       "type": "object",
-      "required": [ "product" ],
+      "required": [
+        "product"
+      ],
       "properties": {
-
         "product": {
           "description": "The code of the product",
           "type": "string"
@@ -262,12 +286,10 @@
         }
       }
     },
-
     "result": {
       "type": "object",
       "description": "A result produced by an analysis tool",
       "properties": {
-
         "rules": {
           "description": "rules",
           "$ref": "#/definitions/rules"
@@ -282,40 +304,42 @@
         }
       }
     },
-
     "rules": {
       "description": "Tool rules",
       "type": "array",
       "items": {
-       "oneOf": [
-         {
-           "$ref": "#/definitions/sastRule"
-           },
+        "oneOf": [
           {
-           "$ref": "#/definitions/sca_cRule"
+            "$ref": "#/definitions/sastRule"
           },
           {
-           "$ref": "#/definitions/sca_sRule"
+            "$ref": "#/definitions/sca_cRule"
+          },
+          {
+            "$ref": "#/definitions/sca_sRule"
           },
           {
             "$ref": "#/definitions/dastRule"
           }
         ]
-       }
-     },
-
+      }
+    },
     "sastRule": {
       "description": "SAST vulnerability rule details",
       "type": "object",
-
       "required": [
-        "type", "id", "name", "severity"
+        "type",
+        "id",
+        "name",
+        "severity"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Rule type",
-          "enum": [ "sast" ]
+          "enum": [
+            "sast"
+          ]
         },
         "id": {
           "type": "string",
@@ -334,7 +358,10 @@
           "description": "Rule description"
         },
         "cwe": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "description": "Vulnerability CWE",
           "items": {
             "$ref": "#/definitions/cwe"
@@ -363,18 +390,22 @@
         }
       }
     },
-
     "sca_sRule": {
       "description": "SCA Security vulnerability rule details",
       "type": "object",
       "required": [
-        "type", "id", "severity", "cveId"
+        "type",
+        "id",
+        "severity",
+        "cveId"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Rule type",
-          "enum": [ "sca_s" ]
+          "enum": [
+            "sca_s"
+          ]
         },
         "id": {
           "type": "string",
@@ -401,7 +432,10 @@
           "description": "CVE Link"
         },
         "cwe": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "description": "Vulnerability CWE",
           "items": {
             "$ref": "#/definitions/cwe"
@@ -416,11 +450,17 @@
           "description": "cvss2 vector"
         },
         "cvss3Score": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Vulnerability score"
         },
         "cvss3Vector": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "cvss3 vector"
         },
         "recommendation": {
@@ -446,8 +486,7 @@
           "type": "string",
           "description": "Vulnerability last modified date date"
         },
-        "references":
-        {
+        "references": {
           "type": "array",
           "description": "Rule references",
           "items": {
@@ -461,19 +500,22 @@
         }
       }
     },
-
     "sca_cRule": {
       "description": "SCA Compliance rule details",
       "type": "object",
-
       "required": [
-        "type", "id", "name", "severity"
+        "type",
+        "id",
+        "name",
+        "severity"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Rule type",
-          "enum": [ "sca_c" ]
+          "enum": [
+            "sca_c"
+          ]
         },
         "id": {
           "type": "string",
@@ -504,18 +546,22 @@
         }
       }
     },
-
     "dastRule": {
       "description": "DAST vulnerability Rule details",
       "type": "object",
       "required": [
-        "type", "id", "name", "severity"
+        "type",
+        "id",
+        "name",
+        "severity"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Rule type",
-          "enum": [ "dast" ]
+          "enum": [
+            "dast"
+          ]
         },
         "id": {
           "type": "string",
@@ -538,7 +584,10 @@
           "description": "Rule recommendation"
         },
         "cwe": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "description": "Vulnerability CWE",
           "items": {
             "$ref": "#/definitions/cwe"
@@ -554,11 +603,17 @@
           "description": "cvss2 vector"
         },
         "cvss3Score": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Vulnerability score"
         },
         "cvss3Vector": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "cvss3 vector"
         },
         "extraInformation": {
@@ -567,36 +622,40 @@
         }
       }
     },
-
     "locations": {
       "description": "Locations",
       "type": "array",
       "items": {
-       "oneOf": [
-         {
-           "$ref": "#/definitions/codebaseLocation"
-           },
+        "oneOf": [
           {
-           "$ref": "#/definitions/componentLocation"
+            "$ref": "#/definitions/codebaseLocation"
+          },
+          {
+            "$ref": "#/definitions/componentLocation"
           },
           {
             "$ref": "#/definitions/instanceLocation"
           }
         ]
-       }
-     },
-
+      }
+    },
     "codebaseLocation": {
       "description": "The location of the codebase",
       "type": "object",
       "required": [
-        "type", "id", "sourceId", "fileName", "language"
+        "type",
+        "id",
+        "sourceId",
+        "fileName",
+        "language"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Location type",
-          "enum": [ "codebase" ]
+          "enum": [
+            "codebase"
+          ]
         },
         "id": {
           "type": "string",
@@ -616,18 +675,23 @@
         }
       }
     },
-
     "componentLocation": {
       "description": "The location of the component",
       "type": "object",
       "required": [
-        "type", "id", "sourceId", "componentName", "componentVersion"
+        "type",
+        "id",
+        "sourceId",
+        "componentName",
+        "componentVersion"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Location type",
-          "enum": [ "component" ]
+          "enum": [
+            "component"
+          ]
         },
         "id": {
           "type": "string",
@@ -686,18 +750,22 @@
         }
       }
     },
-
     "instanceLocation": {
       "description": "The location of the instance",
       "type": "object",
       "required": [
-        "type", "id", "sourceId", "url"
+        "type",
+        "id",
+        "sourceId",
+        "url"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Location type",
-          "enum": [ "instance" ]
+          "enum": [
+            "instance"
+          ]
         },
         "id": {
           "type": "string",
@@ -717,40 +785,42 @@
         }
       }
     },
-
     "findings": {
       "description": "Findings",
       "type": "array",
       "items": {
-       "oneOf": [
-         {
-           "$ref": "#/definitions/sastFinding"
-           },
+        "oneOf": [
           {
-           "$ref": "#/definitions/sca_cFinding"
+            "$ref": "#/definitions/sastFinding"
           },
           {
-           "$ref": "#/definitions/sca_sFinding"
+            "$ref": "#/definitions/sca_cFinding"
+          },
+          {
+            "$ref": "#/definitions/sca_sFinding"
           },
           {
             "$ref": "#/definitions/dastFinding"
           }
         ]
-       }
-     },
-
+      }
+    },
     "sastFinding": {
       "description": "SAST finding",
       "type": "object",
-
       "required": [
-        "type", "id", "ruleId", "locationId"
+        "type",
+        "id",
+        "ruleId",
+        "locationId"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Finding type",
-          "enum": [ "sast" ]
+          "enum": [
+            "sast"
+          ]
         },
         "id": {
           "type": "string",
@@ -760,16 +830,22 @@
           "type": "string",
           "description": "Rule Id"
         },
-         "locationId": {
+        "locationId": {
           "type": "string",
           "description": "Codebase location Id"
         },
         "line": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Line number"
         },
-         "code": {
-          "type": ["string", "null"],
+        "code": {
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Source code"
         },
         "status": {
@@ -782,7 +858,10 @@
           "description": "description"
         },
         "stacks": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "description": "The sequence of function calls leading to the finding",
           "items": {
             "$ref": "#/definitions/stack"
@@ -794,65 +873,22 @@
         }
       }
     },
-
     "sca_sFinding": {
       "description": "SCA Security finding",
       "type": "object",
       "required": [
-        "type", "id", "locationId", "ruleId"
+        "type",
+        "id",
+        "locationId",
+        "ruleId"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Finding type",
-          "enum": [ "sca_s" ]
-        },
-        "id": {
-          "type": "string",
-          "description": "Issue External ID"
-        },
-        "ruleId": {
-          "type": "string",
-          "description": "Rule Id"
-        },
-        "locationId": {
-          "type": "string",
-          "description": "Component location Id"
-        },
-         "path": {
-         "type": "array",
-         "description": "Path",
-         "items": {
-            "type": "string"
-             }
-          },
-        "status": {
-          "type": "string",
-          "description": "Finding status",
-          "$ref": "#/definitions/status"
-        },
-        "description": {
-          "type": "string",
-          "description": "description"
-        },
-        "toolFindingLink": {
-          "type": "string",
-          "description": "Tool finding link"
-        }
-      }
-    },
-
-    "sca_cFinding": {
-      "description": "SCA Compliance finding",
-      "type": "object",
-      "required": [
-        "type", "id", "locationId", "ruleId"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "Finding type",
-          "enum": [ "sca_c" ]
+          "enum": [
+            "sca_s"
+          ]
         },
         "id": {
           "type": "string",
@@ -871,8 +907,8 @@
           "description": "Path",
           "items": {
             "type": "string"
-             }
-         },
+          }
+        },
         "status": {
           "type": "string",
           "description": "Finding status",
@@ -882,7 +918,58 @@
           "type": "string",
           "description": "description"
         },
-         "group": {
+        "toolFindingLink": {
+          "type": "string",
+          "description": "Tool finding link"
+        }
+      }
+    },
+    "sca_cFinding": {
+      "description": "SCA Compliance finding",
+      "type": "object",
+      "required": [
+        "type",
+        "id",
+        "locationId",
+        "ruleId"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Finding type",
+          "enum": [
+            "sca_c"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Issue External ID"
+        },
+        "ruleId": {
+          "type": "string",
+          "description": "Rule Id"
+        },
+        "locationId": {
+          "type": "string",
+          "description": "Component location Id"
+        },
+        "path": {
+          "type": "array",
+          "description": "Path",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": "Finding status",
+          "$ref": "#/definitions/status"
+        },
+        "description": {
+          "type": "string",
+          "description": "description"
+        },
+        "group": {
           "type": "string",
           "description": "License group"
         },
@@ -911,18 +998,23 @@
         }
       }
     },
-
     "dastFinding": {
       "description": "DAST finding",
       "type": "object",
       "required": [
-        "type", "id", "locationId", "ruleId", "url"
+        "type",
+        "id",
+        "locationId",
+        "ruleId",
+        "url"
       ],
       "properties": {
         "type": {
           "type": "string",
           "description": "Finding type",
-          "enum": [ "dast" ]
+          "enum": [
+            "dast"
+          ]
         },
         "id": {
           "type": "string",
@@ -950,24 +1042,55 @@
           "description": "description"
         },
         "httpRequest": {
-          "type": "string",
-          "description": "Http request"
-        },
-        "httpResponce": {
-          "type": "string",
-          "description": "Http responce"
+          "description": "Http request (string in v1.0.1, object with header/body in v1.0.2)",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "header": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
         },
         "toolFindingLink": {
           "type": "string",
           "description": "Tool finding link"
+        },
+        "httpResponse": {
+          "description": "Http response (string in v1.0.1, object with header/body in v1.0.2)",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "header": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
         }
       }
     },
-
     "policyCondition": {
       "description": "Policy condition",
       "type": "object",
-      "required": [ "id" ],
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -987,7 +1110,6 @@
         }
       }
     },
-
     "license": {
       "type": "object",
       "properties": {
@@ -999,16 +1121,15 @@
           "type": "string",
           "description": "The License name"
         }
-
       }
     },
-
     "stack": {
       "description": "Condition",
       "type": "object",
-
       "required": [
-        "locationId", "line", "code"
+        "locationId",
+        "line",
+        "code"
       ],
       "properties": {
         "locationId": {
@@ -1036,24 +1157,31 @@
         }
       }
     },
-
     "severity": {
       "type": "string",
       "enum": [
-        "Low", "Medium", "High", "Critical"
+        "Low",
+        "Medium",
+        "High",
+        "Critical"
       ]
     },
-
     "status": {
       "type": "string",
       "enum": [
-        "To Verify", "Confirmed", "Open", "Fixed", "False Positive", "Accepted risk"
+        "To Verify",
+        "Confirmed",
+        "Open",
+        "Fixed",
+        "False Positive",
+        "Accepted risk"
       ]
     },
-
     "cwe": {
       "type": "object",
-      "required": [ "id" ],
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
           "type": "integer",
@@ -1069,7 +1197,6 @@
         }
       }
     },
-
     "propertyBag": {
       "description": "Key/value pairs that provide additional information about the object",
       "type": "object",

--- a/tests/instance/solidpoint/solidpoint_test.json
+++ b/tests/instance/solidpoint/solidpoint_test.json
@@ -1,0 +1,434 @@
+{
+  "endpoints": [
+    {
+      "har": {
+        "bodySize": 0,
+        "headers": [
+          {
+            "name": "host",
+            "value": "172.16.34.30:3000"
+          },
+          {
+            "name": "proxy-connection",
+            "value": "keep-alive"
+          },
+          {
+            "name": "user-agent",
+            "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4889.0 Safari/537.36"
+          },
+          {
+            "name": "accept",
+            "value": "application/json, text/plain, */*"
+          },
+          {
+            "name": "referer",
+            "value": "http://172.16.34.30:3000/"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, deflate"
+          }
+        ],
+        "httpVersion": "HTTP/1.1",
+        "initiator": {
+          "is_dynamic_crawler": true,
+          "resourceType": "xhr",
+          "type": "script",
+          "wasDuringInteraction": false
+        },
+        "method": "GET",
+        "queryString": [
+          {
+            "name": "name",
+            "value": "Score Board"
+          }
+        ],
+        "url": "http://172.16.34.30:3000/api/Challenges/?name=Score%20Board"
+      },
+      "id": 4564,
+      "tags": [
+        {
+          "attributes": {
+            "analyzer": "Shell injection scanner",
+            "confidence": "tentative",
+            "cve": [],
+            "cvss": [
+              {
+                "metrics": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "score": 9.8
+              }
+            ],
+            "cwe": [
+              "CWE-78"
+            ],
+            "issue": "Shell injection",
+            "issueId": "22904e44bb68013a8c04238884f9202bd0b36cc6529cbe5b1e439278682d66b5",
+            "moduleName": "shell-injection-scanner",
+            "payloads": [
+              {
+                "details": "The value of the &#34;name&#34; parameter in the query string appears to be vulnerable to shell injection attacks.\nThe payload ping -c 5 127\\.0\\.0\\.1 was submitted.\n1 requests were made. The delays were: 2m47.672809841s.",
+                "payload": [
+                  {
+                    "data": "ping -c 5 127\\.0\\.0\\.1",
+                    "selector": {
+                      "path": [
+                        "queryString",
+                        0
+                      ],
+                      "type": "value"
+                    }
+                  }
+                ],
+                "request": {
+                  "blob": "R0VUIC9hcGkvQ2hhbGxlbmdlcy8/bmFtZT1waW5nJTIwLWMlMjA1JTIwMTI3XC4wXC4wXC4xIEhUVFAvMS4xDQpIb3N0OiAxNzIuMTYuMzQuMzA6MzAwMA0KQWNjZXB0OiBhcHBsaWNhdGlvbi9qc29uLCB0ZXh0L3BsYWluLCAqLyoNCkFjY2VwdC1FbmNvZGluZzogZ3ppcCwgZGVmbGF0ZQ0KUHJveHktQ29ubmVjdGlvbjoga2VlcC1hbGl2ZQ0KUmVmZXJlcjogaHR0cDovLzE3Mi4xNi4zNC4zMDozMDAwLw0KVXNlci1BZ2VudDogTW96aWxsYS81LjAgKFgxMTsgTGludXggeDg2XzY0KSBBcHBsZVdlYktpdC81MzcuMzYgKEtIVE1MLCBsaWtlIEdlY2tvKSBDaHJvbWUvMTAwLjAuNDg4OS4wIFNhZmFyaS81MzcuMzYNCg0K",
+                  "type": "blob"
+                },
+                "response": {
+                  "blob": "SFRUUC8xLjEgNTAwIEludGVybmFsIFNlcnZlciBFcnJvcg0KQ29udGVudC1MZW5ndGg6IDU2DQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9dXRmLTgNCkRhdGU6IFdlZCwgMjggSmFuIDIwMjYgMDk6NDU6MzYgR01UDQpYLUNvbnRlbnQtVHlwZS1PcHRpb25zOiBub3NuaWZmDQoNCmRpYWwgdGNwIDE3Mi4xNi4zNC4zMDozMDAwOiBjb25uZWN0OiBjb25uZWN0aW9uIHJlZnVzZWQK",
+                  "type": "blob"
+                }
+              }
+            ],
+            "severity": "critical",
+            "type": "IssueFound",
+            "url": "http://172.16.34.30:3000/api/Challenges/?name=Score%20Board"
+          },
+          "id": 4656,
+          "label": "shell-injection-scanner"
+        }
+      ]
+    },
+    {
+      "har": {
+        "bodySize": 0,
+        "headers": [
+          {
+            "name": "host",
+            "value": "172.16.34.30:3000"
+          },
+          {
+            "name": "proxy-connection",
+            "value": "keep-alive"
+          },
+          {
+            "name": "user-agent",
+            "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4889.0 Safari/537.36"
+          },
+          {
+            "name": "accept",
+            "value": "application/json, text/plain, */*"
+          },
+          {
+            "name": "cookie",
+            "value": "language=en; continueCode=lLrP7weLvQboX2p1gO354xyjdRLUETK7UQQ0Nl8K9mnRzD6qMaWVBJkEZYoO"
+          },
+          {
+            "name": "referer",
+            "value": "http://172.16.34.30:3000/"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, deflate"
+          }
+        ],
+        "httpVersion": "HTTP/1.1",
+        "initiator": {
+          "is_dynamic_crawler": true,
+          "resourceType": "xhr",
+          "type": "script",
+          "wasDuringInteraction": true
+        },
+        "method": "GET",
+        "queryString": [],
+        "url": "http://172.16.34.30:3000/rest/products/38/reviews"
+      },
+      "id": 4602,
+      "tags": [
+        {
+          "attributes": {
+            "analyzer": "Shell injection scanner",
+            "confidence": "tentative",
+            "cve": [],
+            "cvss": [
+              {
+                "metrics": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "score": 9.8
+              }
+            ],
+            "cwe": [
+              "CWE-78"
+            ],
+            "issue": "Shell injection",
+            "issueId": "7b528abc7e217c3320f453bda3369c17cebe1f8b63ceca4d411d1839a7d64cc2",
+            "moduleName": "shell-injection-scanner",
+            "payloads": [
+              {
+                "details": "The pathname parameter #1 appears to be vulnerable to shell injection attacks.\nThe payload %27%3B%20sleep%205%3B%20%27 was submitted.\n1 requests were made. The delays were: 3.026s.",
+                "payload": [
+                  {
+                    "data": "%27%3B%20sleep%205%3B%20%27",
+                    "selector": {
+                      "path": [
+                        "url",
+                        "path",
+                        0
+                      ],
+                      "type": "value"
+                    }
+                  }
+                ],
+                "request": {
+                  "blob": "R0VUIC8lMjclM0IlMjBzbGVlcCUyMDUlM0IlMjAlMjcgSFRUUC8xLjENCkhvc3Q6IDE3Mi4xNi4zNC4zMDozMDAwDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24sIHRleHQvcGxhaW4sICovKg0KQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlDQpDb29raWU6IGxhbmd1YWdlPWVuOyBjb250aW51ZUNvZGU9bExyUDd3ZUx2UWJvWDJwMWdPMzU0eHlqZFJMVUVUSzdVUVEwTmw4SzltblJ6RDZxTWFXVkJKa0VaWW9PDQpQcm94eS1Db25uZWN0aW9uOiBrZWVwLWFsaXZlDQpSZWZlcmVyOiBodHRwOi8vMTcyLjE2LjM0LjMwOjMwMDAvDQpVc2VyLUFnZW50OiBNb3ppbGxhLzUuMCAoWDExOyBMaW51eCB4ODZfNjQpIEFwcGxlV2ViS2l0LzUzNy4zNiAoS0hUTUwsIGxpa2UgR2Vja28pIENocm9tZS8xMDAuMC40ODg5LjAgU2FmYXJpLzUzNy4zNg0KDQo=",
+                  "type": "blob"
+                },
+                "response": {
+                  "blob": "SFRUUC8xLjEgMjAwIE9LDQpUcmFuc2Zlci1FbmNvZGluZzogY2h1bmtlZA0KQWNjZXB0LVJhbmdlczogYnl0ZXMNCkFjY2Vzcy1Db250cm9sLUFsbG93LU9yaWdpbjogKg0KQ2FjaGUtQ29udHJvbDogcHVibGljLCBtYXgtYWdlPTANCkNvbm5lY3Rpb246IGtlZXAtYWxpdmUNCkNvbnRlbnQtVHlwZTogdGV4dC9odG1sOyBjaGFyc2V0PVVURi04DQpEYXRlOiBXZWQsIDI4IEphbiAyMDI2IDA5OjQ0OjE2IEdNVA0KRXRhZzogVy8iN2MzLTE5YzAzZjZiMDc1Ig0KRmVhdHVyZS1Qb2xpY3k6IHBheW1lbnQgJ3NlbGYnDQpLZWVwLUFsaXZlOiB0aW1lb3V0PTUNCkxhc3QtTW9kaWZpZWQ6IFdlZCwgMjggSmFuIDIwMjYgMDk6Mzc6MDQgR01UDQpWYXJ5OiBBY2NlcHQtRW5jb2RpbmcNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNClgtRnJhbWUtT3B0aW9uczogU0FNRU9SSUdJTg0KWC1SZWNydWl0aW5nOiAvIy9qb2JzDQoNCjwhLS0KICB+IENvcHlyaWdodCAoYykgMjAxNC0yMDIzIEJqb2VybiBLaW1taW5pY2ggJiB0aGUgT1dBU1AgSnVpY2UgU2hvcCBjb250cmlidXRvcnMuCiAgfiBTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogTUlUCiAgLS0+PCFET0NUWVBFIGh0bWw+PGh0bWwgbGFuZz0iZW4iPjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+T1dBU1AgSnVpY2UgU2hvcDwvdGl0bGU+CiAgPG1ldGEgbmFtZT0iZGVzY3JpcHRpb24iIGNvbnRlbnQ9IlByb2JhYmx5IHRoZSBtb3N0IG1vZGVybiBhbmQgc29waGlzdGljYXRlZCBpbnNlY3VyZSB3ZWIgYXBwbGljYXRpb24iPgogIDxtZXRhIG5hbWU9InZpZXdwb3J0IiBjb250ZW50PSJ3aWR0aD1kZXZpY2Utd2lkdGgsIGluaXRpYWwtc2NhbGU9MSI+CiAgPGxpbmsgaWQ9ImZhdmljb24iIHJlbD0iaWNvbiIgdHlwZT0iaW1hZ2UveC1pY29uIiBocmVmPSJhc3NldHMvcHVibGljL2Zhdmljb25fanMuaWNvIj4KICA8bGluayByZWw9InN0eWxlc2hlZXQiIHR5cGU9InRleHQvY3NzIiBocmVmPSIvL2NkbmpzLmNsb3VkZmxhcmUuY29tL2FqYXgvbGlicy9jb29raWVjb25zZW50Mi8zLjEuMC9jb29raWVjb25zZW50Lm1pbi5jc3MiPgogIDxzY3JpcHQgc3JjPSIvL2NkbmpzLmNsb3VkZmxhcmUuY29tL2FqYXgvbGlicy9jb29raWVjb25zZW50Mi8zLjEuMC9jb29raWVjb25zZW50Lm1pbi5qcyI+PC9zY3JpcHQ+CiAgPHNjcmlwdCBzcmM9Ii8vY2RuanMuY2xvdWRmbGFyZS5jb20vYWpheC9saWJzL2pxdWVyeS8yLjIuNC9qcXVlcnkubWluLmpzIj48L3NjcmlwdD4KICA8c2NyaXB0PgogICAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoImxvYWQiLCBmdW5jdGlvbigpewogICAgICB3aW5kb3cuY29va2llY29uc2VudC5pbml0aWFsaXNlKHsKICAgICAgICAicGFsZXR0ZSI6IHsKICAgICAgICAgICJwb3B1cCI6IHsgImJhY2tncm91bmQiOiAiIzU0NmU3YSIsICJ0ZXh0IjogIiNmZmZmZmYiIH0sCiAgICAgICAgICAiYnV0dG9uIjogeyAiYmFja2dyb3VuZCI6ICIjNTU4YjJmIiwgInRleHQiOiAiI2ZmZmZmZiIgfQogICAgICAgIH0sCiAgICAgICAgInRoZW1lIjogImNsYXNzaWMiLAogICAgICAgICJwb3NpdGlvbiI6ICJib3R0b20tcmlnaHQiLAogICAgICAgICJjb250ZW50IjogeyAibWVzc2FnZSI6ICJUaGlzIHdlYnNpdGUgdXNlcyBmcnVpdCBjb29raWVzIHRvIGVuc3VyZSB5b3UgZ2V0IHRoZSBqdWljaWVzdCB0cmFja2luZyBleHBlcmllbmNlLiIsICJkaXNtaXNzIjogIk1lIHdhbnQgaXQhIiwgImxpbmsiOiAiQnV0IG1lIHdhaXQhIiwgImhyZWYiOiAiaHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj05UG5iS0wzd3VINCIgfQogICAgICB9KX0pOwogIDwvc2NyaXB0Pgo8c3R5bGU+LmJsdWVncmV5LWxpZ2h0Z3JlZW4tdGhlbWUubWF0LWFwcC1iYWNrZ3JvdW5ke2JhY2tncm91bmQtY29sb3I6IzMwMzAzMDtjb2xvcjojZmZmfUBjaGFyc2V0ICJVVEYtOCI7QG1lZGlhIHNjcmVlbiBhbmQgKC13ZWJraXQtbWluLWRldmljZS1waXhlbC1yYXRpbzowKXt9PC9zdHlsZT48bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9InN0eWxlcy5jc3MiIG1lZGlhPSJwcmludCIgb25sb2FkPSJ0aGlzLm1lZGlhPSdhbGwnIj48bm9zY3JpcHQ+PGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSJzdHlsZXMuY3NzIj48L25vc2NyaXB0PjwvaGVhZD4KPGJvZHkgY2xhc3M9Im1hdC1hcHAtYmFja2dyb3VuZCBibHVlZ3JleS1saWdodGdyZWVuLXRoZW1lIj4KICA8YXBwLXJvb3Q+PC9hcHAtcm9vdD4KPHNjcmlwdCBzcmM9InJ1bnRpbWUuanMiIHR5cGU9Im1vZHVsZSI+PC9zY3JpcHQ+PHNjcmlwdCBzcmM9InBvbHlmaWxscy5qcyIgdHlwZT0ibW9kdWxlIj48L3NjcmlwdD48c2NyaXB0IHNyYz0idmVuZG9yLmpzIiB0eXBlPSJtb2R1bGUiPjwvc2NyaXB0PjxzY3JpcHQgc3JjPSJtYWluLmpzIiB0eXBlPSJtb2R1bGUiPjwvc2NyaXB0PgoKPC9ib2R5PjwvaHRtbD4=",
+                  "type": "blob"
+                }
+              }
+            ],
+            "severity": "critical",
+            "type": "IssueFound",
+            "url": "http://172.16.34.30:3000/rest/products/38/reviews"
+          },
+          "id": 4643,
+          "label": "shell-injection-scanner"
+        }
+      ]
+    },
+    {
+      "har": {
+        "bodySize": 0,
+        "headers": [
+          {
+            "name": "host",
+            "value": "172.16.34.30:3000"
+          },
+          {
+            "name": "proxy-connection",
+            "value": "keep-alive"
+          },
+          {
+            "name": "user-agent",
+            "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4889.0 Safari/537.36"
+          },
+          {
+            "name": "accept",
+            "value": "application/json, text/plain, */*"
+          },
+          {
+            "name": "cookie",
+            "value": "language=en; continueCode=lLrP7weLvQboX2p1gO354xyjdRLUETK7UQQ0Nl8K9mnRzD6qMaWVBJkEZYoO"
+          },
+          {
+            "name": "referer",
+            "value": "http://172.16.34.30:3000/"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, deflate"
+          }
+        ],
+        "httpVersion": "HTTP/1.1",
+        "initiator": {
+          "is_dynamic_crawler": true,
+          "resourceType": "xhr",
+          "type": "script",
+          "wasDuringInteraction": true
+        },
+        "method": "GET",
+        "queryString": [],
+        "url": "http://172.16.34.30:3000/rest/products/37/reviews"
+      },
+      "id": 4606,
+      "tags": [
+        {
+          "attributes": {
+            "analyzer": "Shell injection scanner",
+            "confidence": "tentative",
+            "cve": [],
+            "cvss": [
+              {
+                "metrics": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "score": 9.8
+              }
+            ],
+            "cwe": [
+              "CWE-78"
+            ],
+            "issue": "Shell injection",
+            "issueId": "32bfa3903823b3b9ce9b203ef21b25944c2fb177340a468c6a4c76cfc414e04f",
+            "moduleName": "shell-injection-scanner",
+            "payloads": [
+              {
+                "details": "The pathname parameter #4 appears to be vulnerable to shell injection attacks.\nThe payload %60sleep%203%60 was submitted.\n1 requests were made. The delays were: 3.338s.",
+                "payload": [
+                  {
+                    "data": "%60sleep%203%60",
+                    "selector": {
+                      "path": [
+                        "url",
+                        "path",
+                        3
+                      ],
+                      "type": "value"
+                    }
+                  }
+                ],
+                "request": {
+                  "blob": "R0VUIC9yZXN0L3Byb2R1Y3RzLzM3LyU2MHNsZWVwJTIwMyU2MCBIVFRQLzEuMQ0KSG9zdDogMTcyLjE2LjM0LjMwOjMwMDANCkFjY2VwdDogYXBwbGljYXRpb24vanNvbiwgdGV4dC9wbGFpbiwgKi8qDQpBY2NlcHQtRW5jb2Rpbmc6IGd6aXAsIGRlZmxhdGUNCkNvb2tpZTogbGFuZ3VhZ2U9ZW47IGNvbnRpbnVlQ29kZT1sTHJQN3dlTHZRYm9YMnAxZ08zNTR4eWpkUkxVRVRLN1VRUTBObDhLOW1uUnpENnFNYVdWQkprRVpZb08NClByb3h5LUNvbm5lY3Rpb246IGtlZXAtYWxpdmUNClJlZmVyZXI6IGh0dHA6Ly8xNzIuMTYuMzQuMzA6MzAwMC8NClVzZXItQWdlbnQ6IE1vemlsbGEvNS4wIChYMTE7IExpbnV4IHg4Nl82NCkgQXBwbGVXZWJLaXQvNTM3LjM2IChLSFRNTCwgbGlrZSBHZWNrbykgQ2hyb21lLzEwMC4wLjQ4ODkuMCBTYWZhcmkvNTM3LjM2DQoNCg==",
+                  "type": "blob"
+                },
+                "response": {
+                  "blob": "SFRUUC8xLjEgNTAwIEludGVybmFsIFNlcnZlciBFcnJvcg0KVHJhbnNmZXItRW5jb2Rpbmc6IGNodW5rZWQNCkFjY2Vzcy1Db250cm9sLUFsbG93LU9yaWdpbjogKg0KQ29ubmVjdGlvbjoga2VlcC1hbGl2ZQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uOyBjaGFyc2V0PXV0Zi04DQpEYXRlOiBXZWQsIDI4IEphbiAyMDI2IDA5OjQ1OjA0IEdNVA0KRmVhdHVyZS1Qb2xpY3k6IHBheW1lbnQgJ3NlbGYnDQpLZWVwLUFsaXZlOiB0aW1lb3V0PTUNClZhcnk6IEFjY2VwdC1FbmNvZGluZw0KWC1Db250ZW50LVR5cGUtT3B0aW9uczogbm9zbmlmZg0KWC1GcmFtZS1PcHRpb25zOiBTQU1FT1JJR0lODQpYLVJlY3J1aXRpbmc6IC8jL2pvYnMNCg0KewogICJlcnJvciI6IHsKICAgICJtZXNzYWdlIjogIlVuZXhwZWN0ZWQgcGF0aDogL3Jlc3QvcHJvZHVjdHMvMzcvJTYwc2xlZXAlMjAzJTYwIiwKICAgICJzdGFjayI6ICJFcnJvcjogVW5leHBlY3RlZCBwYXRoOiAvcmVzdC9wcm9kdWN0cy8zNy8lNjBzbGVlcCUyMDMlNjBcbiAgICBhdCAvanVpY2Utc2hvcC9idWlsZC9yb3V0ZXMvYW5ndWxhci5qczoxNToxOFxuICAgIGF0IExheWVyLmhhbmRsZSBbYXMgaGFuZGxlX3JlcXVlc3RdICgvanVpY2Utc2hvcC9ub2RlX21vZHVsZXMvZXhwcmVzcy9saWIvcm91dGVyL2xheWVyLmpzOjk1OjUpXG4gICAgYXQgdHJpbV9wcmVmaXggKC9qdWljZS1zaG9wL25vZGVfbW9kdWxlcy9leHByZXNzL2xpYi9yb3V0ZXIvaW5kZXguanM6MzI4OjEzKVxuICAgIGF0IC9qdWljZS1zaG9wL25vZGVfbW9kdWxlcy9leHByZXNzL2xpYi9yb3V0ZXIvaW5kZXguanM6Mjg2OjlcbiAgICBhdCBGdW5jdGlvbi5wcm9jZXNzX3BhcmFtcyAoL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczozNDY6MTIpXG4gICAgYXQgbmV4dCAoL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczoyODA6MTApXG4gICAgYXQgL2p1aWNlLXNob3AvYnVpbGQvcm91dGVzL3ZlcmlmeS5qczoxMzU6NVxuICAgIGF0IExheWVyLmhhbmRsZSBbYXMgaGFuZGxlX3JlcXVlc3RdICgvanVpY2Utc2hvcC9ub2RlX21vZHVsZXMvZXhwcmVzcy9saWIvcm91dGVyL2xheWVyLmpzOjk1OjUpXG4gICAgYXQgdHJpbV9wcmVmaXggKC9qdWljZS1zaG9wL25vZGVfbW9kdWxlcy9leHByZXNzL2xpYi9yb3V0ZXIvaW5kZXguanM6MzI4OjEzKVxuICAgIGF0IC9qdWljZS1zaG9wL25vZGVfbW9kdWxlcy9leHByZXNzL2xpYi9yb3V0ZXIvaW5kZXguanM6Mjg2OjlcbiAgICBhdCBGdW5jdGlvbi5wcm9jZXNzX3BhcmFtcyAoL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczozNDY6MTIpXG4gICAgYXQgbmV4dCAoL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczoyODA6MTApXG4gICAgYXQgL2p1aWNlLXNob3AvYnVpbGQvcm91dGVzL3ZlcmlmeS5qczo3MTo1XG4gICAgYXQgTGF5ZXIuaGFuZGxlIFthcyBoYW5kbGVfcmVxdWVzdF0gKC9qdWljZS1zaG9wL25vZGVfbW9kdWxlcy9leHByZXNzL2xpYi9yb3V0ZXIvbGF5ZXIuanM6OTU6NSlcbiAgICBhdCB0cmltX3ByZWZpeCAoL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczozMjg6MTMpXG4gICAgYXQgL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczoyODY6OVxuICAgIGF0IEZ1bmN0aW9uLnByb2Nlc3NfcGFyYW1zICgvanVpY2Utc2hvcC9ub2RlX21vZHVsZXMvZXhwcmVzcy9saWIvcm91dGVyL2luZGV4LmpzOjM0NjoxMilcbiAgICBhdCBuZXh0ICgvanVpY2Utc2hvcC9ub2RlX21vZHVsZXMvZXhwcmVzcy9saWIvcm91dGVyL2luZGV4LmpzOjI4MDoxMClcbiAgICBhdCBsb2dnZXIgKC9qdWljZS1zaG9wL25vZGVfbW9kdWxlcy9tb3JnYW4vaW5kZXguanM6MTQ0OjUpXG4gICAgYXQgTGF5ZXIuaGFuZGxlIFthcyBoYW5kbGVfcmVxdWVzdF0gKC9qdWljZS1zaG9wL25vZGVfbW9kdWxlcy9leHByZXNzL2xpYi9yb3V0ZXIvbGF5ZXIuanM6OTU6NSlcbiAgICBhdCB0cmltX3ByZWZpeCAoL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczozMjg6MTMpXG4gICAgYXQgL2p1aWNlLXNob3Avbm9kZV9tb2R1bGVzL2V4cHJlc3MvbGliL3JvdXRlci9pbmRleC5qczoyODY6OSIKICB9Cn0=",
+                  "type": "blob"
+                }
+              }
+            ],
+            "severity": "critical",
+            "type": "IssueFound",
+            "url": "http://172.16.34.30:3000/rest/products/37/reviews"
+          },
+          "id": 4647,
+          "label": "shell-injection-scanner"
+        },
+        {
+          "attributes": {
+            "analyzer": "Shell injection scanner",
+            "confidence": "tentative",
+            "cve": [],
+            "cvss": [
+              {
+                "metrics": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "score": 9.8
+              }
+            ],
+            "cwe": [
+              "CWE-78"
+            ],
+            "issue": "Shell injection",
+            "issueId": "fc30e1b68245ba044eabaad40666e30c22a222266c669636e2a470b002f0a4a6",
+            "moduleName": "shell-injection-scanner",
+            "payloads": [
+              {
+                "details": "The pathname parameter #1 appears to be vulnerable to shell injection attacks.\nThe payload $%28sleep%203%29 was submitted.\n1 requests were made. The delays were: 3.044s.",
+                "payload": [
+                  {
+                    "data": "$%28sleep%203%29",
+                    "selector": {
+                      "path": [
+                        "url",
+                        "path",
+                        0
+                      ],
+                      "type": "value"
+                    }
+                  }
+                ],
+                "request": {
+                  "blob": "R0VUIC8kKHNsZWVwJTIwMykgSFRUUC8xLjENCkhvc3Q6IDE3Mi4xNi4zNC4zMDozMDAwDQpBY2NlcHQ6IGFwcGxpY2F0aW9uL2pzb24sIHRleHQvcGxhaW4sICovKg0KQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlDQpDb29raWU6IGxhbmd1YWdlPWVuOyBjb250aW51ZUNvZGU9bExyUDd3ZUx2UWJvWDJwMWdPMzU0eHlqZFJMVUVUSzdVUVEwTmw4SzltblJ6RDZxTWFXVkJKa0VaWW9PDQpQcm94eS1Db25uZWN0aW9uOiBrZWVwLWFsaXZlDQpSZWZlcmVyOiBodHRwOi8vMTcyLjE2LjM0LjMwOjMwMDAvDQpVc2VyLUFnZW50OiBNb3ppbGxhLzUuMCAoWDExOyBMaW51eCB4ODZfNjQpIEFwcGxlV2ViS2l0LzUzNy4zNiAoS0hUTUwsIGxpa2UgR2Vja28pIENocm9tZS8xMDAuMC40ODg5LjAgU2FmYXJpLzUzNy4zNg0KDQo=",
+                  "type": "blob"
+                },
+                "response": {
+                  "blob": "SFRUUC8xLjEgMjAwIE9LDQpUcmFuc2Zlci1FbmNvZGluZzogY2h1bmtlZA0KQWNjZXB0LVJhbmdlczogYnl0ZXMNCkFjY2Vzcy1Db250cm9sLUFsbG93LU9yaWdpbjogKg0KQ2FjaGUtQ29udHJvbDogcHVibGljLCBtYXgtYWdlPTANCkNvbm5lY3Rpb246IGtlZXAtYWxpdmUNCkNvbnRlbnQtVHlwZTogdGV4dC9odG1sOyBjaGFyc2V0PVVURi04DQpEYXRlOiBXZWQsIDI4IEphbiAyMDI2IDA5OjQ0OjU1IEdNVA0KRXRhZzogVy8iN2MzLTE5YzAzZjZiMDc1Ig0KRmVhdHVyZS1Qb2xpY3k6IHBheW1lbnQgJ3NlbGYnDQpLZWVwLUFsaXZlOiB0aW1lb3V0PTUNCkxhc3QtTW9kaWZpZWQ6IFdlZCwgMjggSmFuIDIwMjYgMDk6Mzc6MDQgR01UDQpWYXJ5OiBBY2NlcHQtRW5jb2RpbmcNClgtQ29udGVudC1UeXBlLU9wdGlvbnM6IG5vc25pZmYNClgtRnJhbWUtT3B0aW9uczogU0FNRU9SSUdJTg0KWC1SZWNydWl0aW5nOiAvIy9qb2JzDQoNCjwhLS0KICB+IENvcHlyaWdodCAoYykgMjAxNC0yMDIzIEJqb2VybiBLaW1taW5pY2ggJiB0aGUgT1dBU1AgSnVpY2UgU2hvcCBjb250cmlidXRvcnMuCiAgfiBTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogTUlUCiAgLS0+PCFET0NUWVBFIGh0bWw+PGh0bWwgbGFuZz0iZW4iPjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+T1dBU1AgSnVpY2UgU2hvcDwvdGl0bGU+CiAgPG1ldGEgbmFtZT0iZGVzY3JpcHRpb24iIGNvbnRlbnQ9IlByb2JhYmx5IHRoZSBtb3N0IG1vZGVybiBhbmQgc29waGlzdGljYXRlZCBpbnNlY3VyZSB3ZWIgYXBwbGljYXRpb24iPgogIDxtZXRhIG5hbWU9InZpZXdwb3J0IiBjb250ZW50PSJ3aWR0aD1kZXZpY2Utd2lkdGgsIGluaXRpYWwtc2NhbGU9MSI+CiAgPGxpbmsgaWQ9ImZhdmljb24iIHJlbD0iaWNvbiIgdHlwZT0iaW1hZ2UveC1pY29uIiBocmVmPSJhc3NldHMvcHVibGljL2Zhdmljb25fanMuaWNvIj4KICA8bGluayByZWw9InN0eWxlc2hlZXQiIHR5cGU9InRleHQvY3NzIiBocmVmPSIvL2NkbmpzLmNsb3VkZmxhcmUuY29tL2FqYXgvbGlicy9jb29raWVjb25zZW50Mi8zLjEuMC9jb29raWVjb25zZW50Lm1pbi5jc3MiPgogIDxzY3JpcHQgc3JjPSIvL2NkbmpzLmNsb3VkZmxhcmUuY29tL2FqYXgvbGlicy9jb29raWVjb25zZW50Mi8zLjEuMC9jb29raWVjb25zZW50Lm1pbi5qcyI+PC9zY3JpcHQ+CiAgPHNjcmlwdCBzcmM9Ii8vY2RuanMuY2xvdWRmbGFyZS5jb20vYWpheC9saWJzL2pxdWVyeS8yLjIuNC9qcXVlcnkubWluLmpzIj48L3NjcmlwdD4KICA8c2NyaXB0PgogICAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoImxvYWQiLCBmdW5jdGlvbigpewogICAgICB3aW5kb3cuY29va2llY29uc2VudC5pbml0aWFsaXNlKHsKICAgICAgICAicGFsZXR0ZSI6IHsKICAgICAgICAgICJwb3B1cCI6IHsgImJhY2tncm91bmQiOiAiIzU0NmU3YSIsICJ0ZXh0IjogIiNmZmZmZmYiIH0sCiAgICAgICAgICAiYnV0dG9uIjogeyAiYmFja2dyb3VuZCI6ICIjNTU4YjJmIiwgInRleHQiOiAiI2ZmZmZmZiIgfQogICAgICAgIH0sCiAgICAgICAgInRoZW1lIjogImNsYXNzaWMiLAogICAgICAgICJwb3NpdGlvbiI6ICJib3R0b20tcmlnaHQiLAogICAgICAgICJjb250ZW50IjogeyAibWVzc2FnZSI6ICJUaGlzIHdlYnNpdGUgdXNlcyBmcnVpdCBjb29raWVzIHRvIGVuc3VyZSB5b3UgZ2V0IHRoZSBqdWljaWVzdCB0cmFja2luZyBleHBlcmllbmNlLiIsICJkaXNtaXNzIjogIk1lIHdhbnQgaXQhIiwgImxpbmsiOiAiQnV0IG1lIHdhaXQhIiwgImhyZWYiOiAiaHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj05UG5iS0wzd3VINCIgfQogICAgICB9KX0pOwogIDwvc2NyaXB0Pgo8c3R5bGU+LmJsdWVncmV5LWxpZ2h0Z3JlZW4tdGhlbWUubWF0LWFwcC1iYWNrZ3JvdW5ke2JhY2tncm91bmQtY29sb3I6IzMwMzAzMDtjb2xvcjojZmZmfUBjaGFyc2V0ICJVVEYtOCI7QG1lZGlhIHNjcmVlbiBhbmQgKC13ZWJraXQtbWluLWRldmljZS1waXhlbC1yYXRpbzowKXt9PC9zdHlsZT48bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9InN0eWxlcy5jc3MiIG1lZGlhPSJwcmludCIgb25sb2FkPSJ0aGlzLm1lZGlhPSdhbGwnIj48bm9zY3JpcHQ+PGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSJzdHlsZXMuY3NzIj48L25vc2NyaXB0PjwvaGVhZD4KPGJvZHkgY2xhc3M9Im1hdC1hcHAtYmFja2dyb3VuZCBibHVlZ3JleS1saWdodGdyZWVuLXRoZW1lIj4KICA8YXBwLXJvb3Q+PC9hcHAtcm9vdD4KPHNjcmlwdCBzcmM9InJ1bnRpbWUuanMiIHR5cGU9Im1vZHVsZSI+PC9zY3JpcHQ+PHNjcmlwdCBzcmM9InBvbHlmaWxscy5qcyIgdHlwZT0ibW9kdWxlIj48L3NjcmlwdD48c2NyaXB0IHNyYz0idmVuZG9yLmpzIiB0eXBlPSJtb2R1bGUiPjwvc2NyaXB0PjxzY3JpcHQgc3JjPSJtYWluLmpzIiB0eXBlPSJtb2R1bGUiPjwvc2NyaXB0PgoKPC9ib2R5PjwvaHRtbD4=",
+                  "type": "blob"
+                }
+              }
+            ],
+            "severity": "critical",
+            "type": "IssueFound",
+            "url": "http://172.16.34.30:3000/rest/products/37/reviews"
+          },
+          "id": 4646,
+          "label": "shell-injection-scanner"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "id": 1432,
+      "resource": {
+        "fetchedAt": "2026-01-28T07:48:56.57428Z",
+        "hash": "2d156b45cb381b5d6aad101e2d6425ff46b9d995ec5e82cd2b8e18260e661c4e",
+        "statusCode": 200,
+        "url": "http://172.16.34.30:3000/"
+      },
+      "tags": [
+        {
+          "attributes": {
+            "analyzer": "Active Signature Scanner",
+            "confidence": "certain",
+            "cve": [],
+            "cvss": [],
+            "cwe": [
+              "CWE-200"
+            ],
+            "description": "A CAA record was discovered. A CAA record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain.",
+            "issue": "CAA Record",
+            "issueId": "4306b012522c828f2594adee57cb9923764ee311712fb9e32f2ce88e6ba452c5",
+            "moduleName": "nuclei-runner",
+            "payloads": [
+              {
+                "payload": [
+                  {
+                    "data": "http://172.16.34.30:3000/",
+                    "selector": "unknown"
+                  }
+                ],
+                "request": {
+                  "blob": "Ozsgb3Bjb2RlOiBRVUVSWSwgc3RhdHVzOiBOT0VSUk9SLCBpZDogMzM5NjcKOzsgZmxhZ3M6IHJkOyBRVUVSWTogMSwgQU5TV0VSOiAwLCBBVVRIT1JJVFk6IDAsIEFERElUSU9OQUw6IDEKCjs7IE9QVCBQU0VVRE9TRUNUSU9OOgo7IEVETlM6IHZlcnNpb24gMDsgZmxhZ3M6OyB1ZHA6IDQwOTYKCjs7IFFVRVNUSU9OIFNFQ1RJT046CjtodHRwOi8vMTcyLjE2LjM0LjMwOjMwMDAvLglJTgkgQ0FBCg==",
+                  "type": "blob"
+                },
+                "response": {
+                  "blob": "Ozsgb3Bjb2RlOiBRVUVSWSwgc3RhdHVzOiBOWERPTUFJTiwgaWQ6IDMzOTY3Cjs7IGZsYWdzOiBxciByZCByYTsgUVVFUlk6IDEsIEFOU1dFUjogMCwgQVVUSE9SSVRZOiAxLCBBRERJVElPTkFMOiAxCgo7OyBPUFQgUFNFVURPU0VDVElPTjoKOyBFRE5TOiB2ZXJzaW9uIDA7IGZsYWdzOjsgdWRwOiAxMjMyCgo7OyBRVUVTVElPTiBTRUNUSU9OOgo7aHR0cDovLzE3Mi4xNi4zNC4zMDozMDAwLy4JSU4JIENBQQoKOzsgQVVUSE9SSVRZIFNFQ1RJT046Ci4JODY0MDAJSU4JU09BCWEucm9vdC1zZXJ2ZXJzLm5ldC4gbnN0bGQudmVyaXNpZ24tZ3JzLmNvbS4gMjAyNjAxMjgwMCAxODAwIDkwMCA2MDQ4MDAgODY0MDAK",
+                  "type": "blob"
+                }
+              }
+            ],
+            "severity": "info",
+            "type": "IssueFound",
+            "url": "http://172.16.34.30:3000/"
+          },
+          "id": 2062,
+          "label": "nuclei-runner"
+        },
+        {
+          "attributes": {
+            "analyzer": "Active Signature Scanner",
+            "confidence": "certain",
+            "cve": [],
+            "cvss": [],
+            "cwe": [],
+            "issue": "robots.txt endpoint prober",
+            "issueId": "0c6a5c0c4099920abd81f0f815903ccf3c6d4bde04ee569985a85ae2dea8f392",
+            "moduleName": "nuclei-runner",
+            "payloads": [
+              {
+                "payload": [
+                  {
+                    "data": "curl -X 'GET' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0' 'http://172.16.34.30:3000/robots.txt'",
+                    "selector": "unknown"
+                  }
+                ],
+                "request": {
+                  "blob": "R0VUIC9yb2JvdHMudHh0IEhUVFAvMS4xDQpIb3N0OiAxNzIuMTYuMzQuMzA6MzAwMA0KVXNlci1BZ2VudDogTW96aWxsYS81LjAgKE1hY2ludG9zaDsgSW50ZWwgTWFjIE9TIFggMTAuMTU7IHJ2OjEwOS4wKSBHZWNrby8yMDEwMDEwMSBGaXJlZm94LzExNy4wDQpDb25uZWN0aW9uOiBjbG9zZQ0KQWNjZXB0OiAqLyoNCkFjY2VwdC1MYW5ndWFnZTogZW4NCkFjY2VwdC1FbmNvZGluZzogZ3ppcA0KDQo=",
+                  "type": "blob"
+                },
+                "response": {
+                  "blob": "SFRUUC8xLjEgMjAwIE9LDQpDb25uZWN0aW9uOiBjbG9zZQ0KQ29udGVudC1MZW5ndGg6IDI4DQpBY2Nlc3MtQ29udHJvbC1BbGxvdy1PcmlnaW46ICoNCkNvbnRlbnQtVHlwZTogdGV4dC9wbGFpbjsgY2hhcnNldD11dGYtOA0KRGF0ZTogV2VkLCAyOCBKYW4gMjAyNiAwODowMToyMSBHTVQNCkV0YWc6IFcvIjFjLThIZ0Y2bU55aHNTRkswcGFzY0M5dUIwd2pYMCINCkZlYXR1cmUtUG9saWN5OiBwYXltZW50ICdzZWxmJw0KVmFyeTogQWNjZXB0LUVuY29kaW5nDQpYLUNvbnRlbnQtVHlwZS1PcHRpb25zOiBub3NuaWZmDQpYLUZyYW1lLU9wdGlvbnM6IFNBTUVPUklHSU4NClgtRnVjaHNpYS1SZXNwb25zZS1UaW1lLU1zOiA2DQpYLVJlY3J1aXRpbmc6IC8jL2pvYnMNCg0KVXNlci1hZ2VudDogKgpEaXNhbGxvdzogL2Z0cA==",
+                  "type": "blob"
+                }
+              }
+            ],
+            "severity": "info",
+            "type": "IssueFound",
+            "url": "http://172.16.34.30:3000/"
+          },
+          "id": 2061,
+          "label": "nuclei-runner"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/instance/solidpoint/solidpoint_test_hub.json
+++ b/tests/instance/solidpoint/solidpoint_test_hub.json
@@ -1,0 +1,196 @@
+{
+    "version": "1.0.2",
+    "scans": [
+        {
+            "scanDetails": {
+                "id": "f4a3c9e8-9d05-4954-82a3-edab656381e4",
+                "description": "Import solidpoint results"
+            },
+            "source": [
+                {
+                    "id": "98f5e38d-b989-44f8-b23a-359b52d3b5c4",
+                    "type": "instance",
+                    "name": "test-app",
+                    "url": "http://172.16.34.30:3000",
+                    "stage": "ST"
+                }
+            ],
+            "tool": {
+                "product": "solidpoint"
+            },
+            "results": [
+                {
+                    "rules": [
+                        {
+                            "type": "dast",
+                            "name": "Shell injection",
+                            "id": "Shell injection",
+                            "severity": "Critical",
+                            "cwe": [
+                                {
+                                    "id": 78
+                                }
+                            ],
+                            "description": "Shell injection\n\n\n"
+                        },
+                        {
+                            "type": "dast",
+                            "name": "CAA Record",
+                            "id": "CAA Record",
+                            "severity": "Low",
+                            "cwe": [
+                                {
+                                    "id": 200
+                                }
+                            ],
+                            "description": "CAA Record\n\nA CAA record was discovered. A CAA record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain.\n"
+                        },
+                        {
+                            "type": "dast",
+                            "name": "robots.txt endpoint prober",
+                            "id": "robots.txt endpoint prober",
+                            "severity": "Low",
+                            "cwe": null,
+                            "description": "robots.txt endpoint prober\n\n\n"
+                        }
+                    ],
+                    "locations": [
+                        {
+                            "type": "instance",
+                            "id": "1cd4eb00ee1aec5ee7a568a9e554a073",
+                            "sourceId": "98f5e38d-b989-44f8-b23a-359b52d3b5c4",
+                            "url": "http://172.16.34.30:3000/api/Challenges/?name=Score%20Board",
+                            "description": "**URL:** GET http://172.16.34.30:3000/api/Challenges/?name=Score%20Board\n**Analyzer:** Shell injection scanner\n**Module:** shell-injection-scanner\n**Confidence:** tentative\n\n**Payloads:**\nThe value of the &#34;name&#34; parameter in the query string appears to be vulnerable to shell injection attacks.\nThe payload ping -c 5 127\\.0\\.0\\.1 was submitted.\n1 requests were made. The delays were: 2m47.672809841s.\n**Payload:** `ping -c 5 127\\.0\\.0\\.1`"
+                        },
+                        {
+                            "type": "instance",
+                            "id": "0cba79a4892609c4bddd0d51cc15b0dd",
+                            "sourceId": "98f5e38d-b989-44f8-b23a-359b52d3b5c4",
+                            "url": "http://172.16.34.30:3000/rest/products/38/reviews",
+                            "description": "**URL:** GET http://172.16.34.30:3000/rest/products/38/reviews\n**Analyzer:** Shell injection scanner\n**Module:** shell-injection-scanner\n**Confidence:** tentative\n\n**Payloads:**\nThe pathname parameter #1 appears to be vulnerable to shell injection attacks.\nThe payload %27%3B%20sleep%205%3B%20%27 was submitted.\n1 requests were made. The delays were: 3.026s.\n**Payload:** `%27%3B%20sleep%205%3B%20%27`"
+                        },
+                        {
+                            "type": "instance",
+                            "id": "1d7395893423945d60b359a0e5630021",
+                            "sourceId": "98f5e38d-b989-44f8-b23a-359b52d3b5c4",
+                            "url": "http://172.16.34.30:3000/rest/products/37/reviews",
+                            "description": "**URL:** GET http://172.16.34.30:3000/rest/products/37/reviews\n**Analyzer:** Shell injection scanner\n**Module:** shell-injection-scanner\n**Confidence:** tentative\n\n**Payloads:**\nThe pathname parameter #4 appears to be vulnerable to shell injection attacks.\nThe payload %60sleep%203%60 was submitted.\n1 requests were made. The delays were: 3.338s.\n**Payload:** `%60sleep%203%60`"
+                        },
+                        {
+                            "type": "instance",
+                            "id": "6653b551b82da90b83974fdaf25ed769",
+                            "sourceId": "98f5e38d-b989-44f8-b23a-359b52d3b5c4",
+                            "url": "http://172.16.34.30:3000/",
+                            "description": "**URL:** http://172.16.34.30:3000/\n**Analyzer:** Active Signature Scanner\n**Module:** nuclei-runner\n**Confidence:** certain\n\nA CAA record was discovered. A CAA record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain.\n\n**Payloads:**\n**Payload:** `http://172.16.34.30:3000/`"
+                        }
+                    ],
+                    "findings": [
+                        {
+                            "type": "dast",
+                            "id": "e4ce1e5efafc0b496b91153396fcbd0a",
+                            "ruleId": "Shell injection",
+                            "locationId": "1cd4eb00ee1aec5ee7a568a9e554a073",
+                            "url": "http://172.16.34.30:3000/api/Challenges/?name=Score%20Board",
+                            "status": "To Verify",
+                            "description": "<p><strong>URL:</strong> GET http://172.16.34.30:3000/api/Challenges/?name=Score%20Board<br /><strong>Analyzer:</strong> Shell injection scanner<br /><strong>Module:</strong> shell-injection-scanner<br /><strong>Confidence:</strong> tentative</p><p><strong>Payloads:</strong><br />The value of the &#34;name&#34; parameter in the query string appears to be vulnerable to shell injection attacks.<br />The payload ping -c 5 127.0.0.1 was submitted.<br />1 requests were made. The delays were: 2m47.672809841s.<br /><strong>Payload:</strong> <code>ping -c 5 127\\.0\\.0\\.1</code></p>",
+                            "httpRequest": {
+                                "header": "GET /api/Challenges/?name=ping%20-c%205%20127\\.0\\.0\\.1 HTTP/1.1\r\nHost: 172.16.34.30:3000\r\nAccept: application/json, text/plain, */*\r\nAccept-Encoding: gzip, deflate\r\nProxy-Connection: keep-alive\r\nReferer: http://172.16.34.30:3000/\r\nUser-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4889.0 Safari/537.36",
+                                "body": ""
+                            },
+                            "httpResponse": {
+                                "header": "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 56\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 28 Jan 2026 09:45:36 GMT\r\nX-Content-Type-Options: nosniff",
+                                "body": "dial tcp 172.16.34.30:3000: connect: connection refused\n"
+                            }
+                        },
+                        {
+                            "type": "dast",
+                            "id": "2af15a9194702012bda5dfe92b22dd6b",
+                            "ruleId": "Shell injection",
+                            "locationId": "0cba79a4892609c4bddd0d51cc15b0dd",
+                            "url": "http://172.16.34.30:3000/rest/products/38/reviews",
+                            "status": "To Verify",
+                            "description": "<p><strong>URL:</strong> GET http://172.16.34.30:3000/rest/products/38/reviews<br /><strong>Analyzer:</strong> Shell injection scanner<br /><strong>Module:</strong> shell-injection-scanner<br /><strong>Confidence:</strong> tentative</p><p><strong>Payloads:</strong><br />The pathname parameter #1 appears to be vulnerable to shell injection attacks.<br />The payload %27%3B%20sleep%205%3B%20%27 was submitted.<br />1 requests were made. The delays were: 3.026s.<br /><strong>Payload:</strong> <code>%27%3B%20sleep%205%3B%20%27</code></p>",
+                            "httpRequest": {
+                                "header": "GET /%27%3B%20sleep%205%3B%20%27 HTTP/1.1\r\nHost: 172.16.34.30:3000\r\nAccept: application/json, text/plain, */*\r\nAccept-Encoding: gzip, deflate\r\nCookie: language=en; continueCode=lLrP7weLvQboX2p1gO354xyjdRLUETK7UQQ0Nl8K9mnRzD6qMaWVBJkEZYoO\r\nProxy-Connection: keep-alive\r\nReferer: http://172.16.34.30:3000/\r\nUser-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4889.0 Safari/537.36",
+                                "body": ""
+                            },
+                            "httpResponse": {
+                                "header": "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nAccept-Ranges: bytes\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: public, max-age=0\r\nConnection: keep-alive\r\nContent-Type: text/html; charset=UTF-8\r\nDate: Wed, 28 Jan 2026 09:44:16 GMT\r\nEtag: W/\"7c3-19c03f6b075\"\r\nFeature-Policy: payment 'self'\r\nKeep-Alive: timeout=5\r\nLast-Modified: Wed, 28 Jan 2026 09:37:04 GMT\r\nVary: Accept-Encoding\r\nX-Content-Type-Options: nosniff\r\nX-Frame-Options: SAMEORIGIN\r\nX-Recruiting: /#/jobs",
+                                "body": "<!--\n  ~ Copyright (c) 2014-2023 Bjoern Kimminich & the OWASP Juice Shop contributors.\n  ~ SPDX-License-Identifier: MIT\n  --><!DOCTYPE html><html lang=\"en\"><head>\n  <meta charset=\"utf-8\">\n  <title>OWASP Juice Shop</title>\n  <meta name=\"description\" content=\"Probably the most modern and sophisticated insecure web application\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n  <link id=\"favicon\" rel=\"icon\" type=\"image/x-icon\" href=\"assets/public/favicon_js.ico\">\n  <link rel=\"stylesheet\" type=\"text/css\" href=\"//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css\">\n  <script src=\"//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js\"></script>\n  <script src=\"//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js\"></script>\n  <script>\n    window.addEventListener(\"load\", function(){\n      window.cookieconsent.initialise({\n        \"palette\": {\n          \"popup\": { \"background\": \"#546e7a\", \"text\": \"#ffffff\" },\n          \"button\": { \"background\": \"#558b2f\", \"text\": \"#ffffff\" }\n        },\n        \"theme\": \"classic\",\n        \"position\": \"bottom-right\",\n        \"content\": { \"message\": \"This website uses fruit cookies to ensure you get the juiciest tracking experience.\", \"dismiss\": \"Me want it!\", \"link\": \"But me wait!\", \"href\": \"https://www.youtube.com/watch?v=9PnbKL3wuH4\" }\n      })});\n  </script>\n<style>.bluegrey-lightgreen-theme.mat-app-background{background-color:#303030;color:#fff}@charset \"UTF-8\";@media screen and (-webkit-min-device-pixel-ratio:0){}</style><link rel=\"stylesheet\" href=\"styles.css\" media=\"print\" onload=\"this.media='all'\"><noscript><link rel=\"stylesheet\" href=\"styles.css\"></noscript></head>\n<body class=\"mat-app-background bluegrey-lightgreen-theme\">\n  <app-root></app-root>\n<script src=\"runtime.js\" type=\"module\"></script><script src=\"polyfills.js\" type=\"module\"></script><script src=\"vendor.js\" type=\"module\"></script><script src=\"main.js\" type=\"module\"></script>\n\n</body></html>"
+                            }
+                        },
+                        {
+                            "type": "dast",
+                            "id": "1411461a23f6d552fb7976e7a02531fe",
+                            "ruleId": "Shell injection",
+                            "locationId": "1d7395893423945d60b359a0e5630021",
+                            "url": "http://172.16.34.30:3000/rest/products/37/reviews",
+                            "status": "To Verify",
+                            "description": "<p><strong>URL:</strong> GET http://172.16.34.30:3000/rest/products/37/reviews<br /><strong>Analyzer:</strong> Shell injection scanner<br /><strong>Module:</strong> shell-injection-scanner<br /><strong>Confidence:</strong> tentative</p><p><strong>Payloads:</strong><br />The pathname parameter #4 appears to be vulnerable to shell injection attacks.<br />The payload %60sleep%203%60 was submitted.<br />1 requests were made. The delays were: 3.338s.<br /><strong>Payload:</strong> <code>%60sleep%203%60</code></p>",
+                            "httpRequest": {
+                                "header": "GET /rest/products/37/%60sleep%203%60 HTTP/1.1\r\nHost: 172.16.34.30:3000\r\nAccept: application/json, text/plain, */*\r\nAccept-Encoding: gzip, deflate\r\nCookie: language=en; continueCode=lLrP7weLvQboX2p1gO354xyjdRLUETK7UQQ0Nl8K9mnRzD6qMaWVBJkEZYoO\r\nProxy-Connection: keep-alive\r\nReferer: http://172.16.34.30:3000/\r\nUser-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4889.0 Safari/537.36",
+                                "body": ""
+                            },
+                            "httpResponse": {
+                                "header": "HTTP/1.1 500 Internal Server Error\r\nTransfer-Encoding: chunked\r\nAccess-Control-Allow-Origin: *\r\nConnection: keep-alive\r\nContent-Type: application/json; charset=utf-8\r\nDate: Wed, 28 Jan 2026 09:45:04 GMT\r\nFeature-Policy: payment 'self'\r\nKeep-Alive: timeout=5\r\nVary: Accept-Encoding\r\nX-Content-Type-Options: nosniff\r\nX-Frame-Options: SAMEORIGIN\r\nX-Recruiting: /#/jobs",
+                                "body": "{\n  \"error\": {\n    \"message\": \"Unexpected path: /rest/products/37/%60sleep%203%60\",\n    \"stack\": \"Error: Unexpected path: /rest/products/37/%60sleep%203%60\\n    at /juice-shop/build/routes/angular.js:15:18\\n    at Layer.handle [as handle_request] (/juice-shop/node_modules/express/lib/router/layer.js:95:5)\\n    at trim_prefix (/juice-shop/node_modules/express/lib/router/index.js:328:13)\\n    at /juice-shop/node_modules/express/lib/router/index.js:286:9\\n    at Function.process_params (/juice-shop/node_modules/express/lib/router/index.js:346:12)\\n    at next (/juice-shop/node_modules/express/lib/router/index.js:280:10)\\n    at /juice-shop/build/routes/verify.js:135:5\\n    at Layer.handle [as handle_request] (/juice-shop/node_modules/express/lib/router/layer.js:95:5)\\n    at trim_prefix (/juice-shop/node_modules/express/lib/router/index.js:328:13)\\n    at /juice-shop/node_modules/express/lib/router/index.js:286:9\\n    at Function.process_params (/juice-shop/node_modules/express/lib/router/index.js:346:12)\\n    at next (/juice-shop/node_modules/express/lib/router/index.js:280:10)\\n    at /juice-shop/build/routes/verify.js:71:5\\n    at Layer.handle [as handle_request] (/juice-shop/node_modules/express/lib/router/layer.js:95:5)\\n    at trim_prefix (/juice-shop/node_modules/express/lib/router/index.js:328:13)\\n    at /juice-shop/node_modules/express/lib/router/index.js:286:9\\n    at Function.process_params (/juice-shop/node_modules/express/lib/router/index.js:346:12)\\n    at next (/juice-shop/node_modules/express/lib/router/index.js:280:10)\\n    at logger (/juice-shop/node_modules/morgan/index.js:144:5)\\n    at Layer.handle [as handle_request] (/juice-shop/node_modules/express/lib/router/layer.js:95:5)\\n    at trim_prefix (/juice-shop/node_modules/express/lib/router/index.js:328:13)\\n    at /juice-shop/node_modules/express/lib/router/index.js:286:9\"\n  }\n}"
+                            }
+                        },
+                        {
+                            "type": "dast",
+                            "id": "ffbc705de62759cf562f3056fb2a693b",
+                            "ruleId": "Shell injection",
+                            "locationId": "1d7395893423945d60b359a0e5630021",
+                            "url": "http://172.16.34.30:3000/rest/products/37/reviews",
+                            "status": "To Verify",
+                            "description": "<p><strong>URL:</strong> GET http://172.16.34.30:3000/rest/products/37/reviews<br /><strong>Analyzer:</strong> Shell injection scanner<br /><strong>Module:</strong> shell-injection-scanner<br /><strong>Confidence:</strong> tentative</p><p><strong>Payloads:</strong><br />The pathname parameter #1 appears to be vulnerable to shell injection attacks.<br />The payload $%28sleep%203%29 was submitted.<br />1 requests were made. The delays were: 3.044s.<br /><strong>Payload:</strong> <code>$%28sleep%203%29</code></p>",
+                            "httpRequest": {
+                                "header": "GET /$(sleep%203) HTTP/1.1\r\nHost: 172.16.34.30:3000\r\nAccept: application/json, text/plain, */*\r\nAccept-Encoding: gzip, deflate\r\nCookie: language=en; continueCode=lLrP7weLvQboX2p1gO354xyjdRLUETK7UQQ0Nl8K9mnRzD6qMaWVBJkEZYoO\r\nProxy-Connection: keep-alive\r\nReferer: http://172.16.34.30:3000/\r\nUser-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4889.0 Safari/537.36",
+                                "body": ""
+                            },
+                            "httpResponse": {
+                                "header": "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nAccept-Ranges: bytes\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: public, max-age=0\r\nConnection: keep-alive\r\nContent-Type: text/html; charset=UTF-8\r\nDate: Wed, 28 Jan 2026 09:44:55 GMT\r\nEtag: W/\"7c3-19c03f6b075\"\r\nFeature-Policy: payment 'self'\r\nKeep-Alive: timeout=5\r\nLast-Modified: Wed, 28 Jan 2026 09:37:04 GMT\r\nVary: Accept-Encoding\r\nX-Content-Type-Options: nosniff\r\nX-Frame-Options: SAMEORIGIN\r\nX-Recruiting: /#/jobs",
+                                "body": "<!--\n  ~ Copyright (c) 2014-2023 Bjoern Kimminich & the OWASP Juice Shop contributors.\n  ~ SPDX-License-Identifier: MIT\n  --><!DOCTYPE html><html lang=\"en\"><head>\n  <meta charset=\"utf-8\">\n  <title>OWASP Juice Shop</title>\n  <meta name=\"description\" content=\"Probably the most modern and sophisticated insecure web application\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n  <link id=\"favicon\" rel=\"icon\" type=\"image/x-icon\" href=\"assets/public/favicon_js.ico\">\n  <link rel=\"stylesheet\" type=\"text/css\" href=\"//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css\">\n  <script src=\"//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js\"></script>\n  <script src=\"//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js\"></script>\n  <script>\n    window.addEventListener(\"load\", function(){\n      window.cookieconsent.initialise({\n        \"palette\": {\n          \"popup\": { \"background\": \"#546e7a\", \"text\": \"#ffffff\" },\n          \"button\": { \"background\": \"#558b2f\", \"text\": \"#ffffff\" }\n        },\n        \"theme\": \"classic\",\n        \"position\": \"bottom-right\",\n        \"content\": { \"message\": \"This website uses fruit cookies to ensure you get the juiciest tracking experience.\", \"dismiss\": \"Me want it!\", \"link\": \"But me wait!\", \"href\": \"https://www.youtube.com/watch?v=9PnbKL3wuH4\" }\n      })});\n  </script>\n<style>.bluegrey-lightgreen-theme.mat-app-background{background-color:#303030;color:#fff}@charset \"UTF-8\";@media screen and (-webkit-min-device-pixel-ratio:0){}</style><link rel=\"stylesheet\" href=\"styles.css\" media=\"print\" onload=\"this.media='all'\"><noscript><link rel=\"stylesheet\" href=\"styles.css\"></noscript></head>\n<body class=\"mat-app-background bluegrey-lightgreen-theme\">\n  <app-root></app-root>\n<script src=\"runtime.js\" type=\"module\"></script><script src=\"polyfills.js\" type=\"module\"></script><script src=\"vendor.js\" type=\"module\"></script><script src=\"main.js\" type=\"module\"></script>\n\n</body></html>"
+                            }
+                        },
+                        {
+                            "type": "dast",
+                            "id": "f0097203ece439825f1f5eb8db95e3f2",
+                            "ruleId": "CAA Record",
+                            "locationId": "6653b551b82da90b83974fdaf25ed769",
+                            "url": "http://172.16.34.30:3000/",
+                            "status": "To Verify",
+                            "description": "<p><strong>URL:</strong> http://172.16.34.30:3000/<br /><strong>Analyzer:</strong> Active Signature Scanner<br /><strong>Module:</strong> nuclei-runner<br /><strong>Confidence:</strong> certain</p><p>A CAA record was discovered. A CAA record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain.</p><p><strong>Payloads:</strong><br /><strong>Payload:</strong> <code>http://172.16.34.30:3000/</code></p>",
+                            "httpRequest": {
+                                "header": ";; opcode: QUERY, status: NOERROR, id: 33967\n;; flags: rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1",
+                                "body": ";; OPT PSEUDOSECTION:\n; EDNS: version 0; flags:; udp: 4096\n\n;; QUESTION SECTION:\n;http://172.16.34.30:3000/.\tIN\t CAA\n"
+                            },
+                            "httpResponse": {
+                                "header": ";; opcode: QUERY, status: NXDOMAIN, id: 33967\n;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1",
+                                "body": ";; OPT PSEUDOSECTION:\n; EDNS: version 0; flags:; udp: 1232\n\n;; QUESTION SECTION:\n;http://172.16.34.30:3000/.\tIN\t CAA\n\n;; AUTHORITY SECTION:\n.\t86400\tIN\tSOA\ta.root-servers.net. nstld.verisign-grs.com. 2026012800 1800 900 604800 86400\n"
+                            }
+                        },
+                        {
+                            "type": "dast",
+                            "id": "5e54e55111dac33081ff33c457c7ff24",
+                            "ruleId": "robots.txt endpoint prober",
+                            "locationId": "6653b551b82da90b83974fdaf25ed769",
+                            "url": "http://172.16.34.30:3000/",
+                            "status": "To Verify",
+                            "description": "<p><strong>URL:</strong> http://172.16.34.30:3000/<br /><strong>Analyzer:</strong> Active Signature Scanner<br /><strong>Module:</strong> nuclei-runner<br /><strong>Confidence:</strong> certain</p><p><strong>Payloads:</strong><br /><strong>Payload:</strong> <code>curl -X 'GET' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0' 'http://172.16.34.30:3000/robots.txt'</code></p>",
+                            "httpRequest": {
+                                "header": "GET /robots.txt HTTP/1.1\r\nHost: 172.16.34.30:3000\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0\r\nConnection: close\r\nAccept: */*\r\nAccept-Language: en\r\nAccept-Encoding: gzip",
+                                "body": ""
+                            },
+                            "httpResponse": {
+                                "header": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 28\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 28 Jan 2026 08:01:21 GMT\r\nEtag: W/\"1c-8HgF6mNyhsSFK0pascC9uB0wjX0\"\r\nFeature-Policy: payment 'self'\r\nVary: Accept-Encoding\r\nX-Content-Type-Options: nosniff\r\nX-Frame-Options: SAMEORIGIN\r\nX-Fuchsia-Response-Time-Ms: 6\r\nX-Recruiting: /#/jobs",
+                                "body": "User-agent: *\nDisallow: /ftp"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "$schema": "https://docs.appsec-hub.ru/"
+}


### PR DESCRIPTION
Add new parser for SolidPoint DAST scanner JSON reports. The parser processes both endpoints and resources sections, extracts IssueFound tags with payloads, CWE, CVSS data, and decodes base64 request/response blobs.

Changes:
- New converters/parsers/solidpoint.py parser
- Hub schema v1.0.2: httpRequest/httpResponse as structured objects
- --report-version CLI argument (1.0.1 default, 1.0.2 optional)
- dupe_key guard in additional.py to prevent false deduplication
- Updated README with SolidPoint docs
- Test data for SolidPoint parser